### PR TITLE
minor cleanup of invoker env templates

### DIFF
--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -269,6 +269,10 @@ imagePullSecrets:
     configMapKeyRef:
       name: {{ .Release.Name }}-whisk.config
       key: whisk_api_host_name
+{{- end -}}
+
+{{/* Environment variables required for invoker containerpool/containerfactory configuration */}}
+{{- define "openwhisk.invoker.containerconfig" -}}
 - name: "CONFIG_whisk_docker_containerFactory_useRunc"
   value: {{ .Values.invoker.containerFactory.useRunc | quote }}
 - name: "CONFIG_whisk_containerPool_userMemory"

--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -180,4 +180,5 @@ spec:
 
 {{- if .Values.controller.lean }}
 {{ include "openwhisk.invoker.apihost" . | indent 8 }}
+{{ include "openwhisk.invoker.containerconfig" . | indent 8 }}
 {{- end }}

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -86,6 +86,9 @@ spec:
           # Needed by invoker to set the environment variable __OW_API_HOST in action containers
 {{ include "openwhisk.invoker.apihost" . | indent 10 }}
 
+          # Needed by invoker to configure the container factory & container pool
+{{ include "openwhisk.invoker.containerconfig" . | indent 10 }}
+
 {{- if not .Values.invoker.containerFactory.networkConfig.dns.inheritInvokerConfig }}
 {{- if ne .Values.invoker.containerFactory.networkConfig.dns.overrides.nameservers "" }}
           # DNS Server(s) to be used by action containers


### PR DESCRIPTION
Noticed when reviewing #513 that we had allowed
multiple concerns to get into the same helper macro.
Break into two macros so that intent of each is clear.