### PR TITLE
default ingress annotation

### DIFF
--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -55,6 +55,7 @@ whisk:
     apiHostProto: "https"
     type: NodePort
     annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     domain: "domain"
     tls:
       enabled: false


### PR DESCRIPTION
Add proxy-body-size annotation to default ingress annotations
defined in values.yaml.

Fixes #509.