### PR TITLE
bump openwhisk core version to get updated kubernetes client

### DIFF
--- a/helm/openwhisk/Chart.yaml
+++ b/helm/openwhisk/Chart.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 description: An open source, distributed serverless platform that executes functions in response to events at any scale
 name: openwhisk
-version: 0.1.6
+version: 0.1.7
 icon: https://raw.githubusercontent.com/apache/openwhisk/682eb5b62ee6ba8017ab54226c2ace3637f4f1ec/docs/images/whisk_icon_full-color_with_tm_64x64-300dpi.png
 keywords:
   - Apache OpenWhisk

--- a/helm/openwhisk/configMapFiles/tests/systemTest/myTask.sh
+++ b/helm/openwhisk/configMapFiles/tests/systemTest/myTask.sh
@@ -23,7 +23,7 @@ cd /openwhisk
 git checkout $OW_GIT_TAG_OPENWHISK
 
 # compile test suite
-./gradlew --console=plain compileTestsScala
+./gradlew --console=plain compileTestScala
 
 # run tests:testSystemBasic
 ./gradlew --console=plain :tests:testSystemBasic -Dwhisk.auth="$WSK_AUTH" -Dwhisk.server=$WSK_API_HOST_URL -Dopenwhisk.home=/openwhisk

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -130,9 +130,9 @@ whisk:
     includeSystemTests: false
   versions:
     openwhisk:
-      buildDate: "2019-08-07-11:22:17Z"
-      buildNo: "20190807a"
-      gitTag: "9bef49fcd47f7922e4226ff7a97385f1313f7d64"
+      buildDate: "2019-09-06-03:45:52Z"
+      buildNo: "20190906a"
+      gitTag: "b05b7ff21c414aac31a325c68ae522e5c8a17dd6"
     openwhiskCli:
       # more recent than 0.10.0 to pick up bug fix in commmit 457c17d
       tag: "457c17d"
@@ -156,7 +156,7 @@ k8s:
 # Images used to run auxillary tasks/jobs
 utility:
   imageName: "openwhisk/ow-utils"
-  imageTag: "9bef49f"
+  imageTag: "b05b7ff"
   imagePullPolicy: "IfNotPresent"
 
 # Docker registry
@@ -240,7 +240,7 @@ nginx:
 # Controller configurations
 controller:
   imageName: "openwhisk/controller"
-  imageTag: "9bef49f"
+  imageTag: "b05b7ff"
   imagePullPolicy: "IfNotPresent"
   replicaCount: 1
   restartPolicy: "Always"
@@ -252,7 +252,7 @@ controller:
 # Invoker configurations
 invoker:
   imageName: "openwhisk/invoker"
-  imageTag: "9bef49f"
+  imageTag: "b05b7ff"
   imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
   port: 8080


### PR DESCRIPTION
Pick up core openwhisk PR-4606 that updated invoker to use
'io.fabric8:kubernetes-client:4.4.2'.