### PR TITLE
added Rust 1.34 support to deploy-kube

### DIFF
--- a/helm/openwhisk/runtimes.json
+++ b/helm/openwhisk/runtimes.json
@@ -175,6 +175,22 @@
                 }
             }
         ],
+        "rust": [
+            {
+                "kind": "rust:1.34",
+                "default": true,
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                },
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "actionloop-rust-v1.34",
+                    "tag": "1.13.0-incubating"
+                }
+            }
+        ],
         "dotnet": [
             {
                 "kind": "dotnet:2.2",

--- a/helm/openwhisk/runtimes.json
+++ b/helm/openwhisk/runtimes.json
@@ -186,8 +186,8 @@
                 },
                 "image": {
                     "prefix": "openwhisk",
-                    "name": "actionloop-rust-v1.34",
-                    "tag": "1.13.0-incubating"
+                    "name": "action-rust-v1.34",
+                    "tag": "1.0.0"
                 }
             }
         ],


### PR DESCRIPTION
In order to fully integrate Rust support to Openwhisk in this PR we are adding the information about the rust docker container into the runtime manifest. This PR is part of the work proposed in this issue: apache/openwhisk#4443