### PR TITLE
fix version of Helm to v2.14.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ Kubernetes cluster.
 
 For details on installing Helm, see these [instructions](docs/helm.md).
 
+WARNING: There is a [serious regression in Helm v2.15.0](https://github.com/helm/helm/issues/6708)
+that impacts the OpenWhisk chart.  You should use Helm v2.14.3.
+
 In short if you already have the `helm` cli installed on your development machine,
 you will need to execute these two commands and wait a few seconds for the
 `tiller-deploy` pod in the `kube-system` namespace to be in the `Running` state.

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -32,7 +32,11 @@ setup on your Kubernetes cluster.
 README.md.
 
 2. Follow the Helm [install instructions](https://github.com/kubernetes/helm)
-for your platform.
+for your platform to install Helm v2.14.3.
+
+WARNING: There is a [serious regression in Helm v2.15.0](https://github.com/helm/helm/issues/6708)
+that impacts the OpenWhisk chart.  You cannout use versions of Helm newer than v2.14.3 until
+a there is a 2.15.x release with a fix for the regression.
 
 3. Run the following command to init `Helm Tiller`:
 ```shell

--- a/tools/travis/start-kind.sh
+++ b/tools/travis/start-kind.sh
@@ -53,7 +53,7 @@ pushd /tmp
   sudo cp wsk /usr/local/bin/wsk
 
   # Download and install helm
-  curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh && chmod +x get_helm.sh && ./get_helm.sh
+  curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh && chmod +x get_helm.sh && ./get_helm.sh --version v2.14.3
 popd
 
 # Pods running in kube-system namespace should have cluster-admin role


### PR DESCRIPTION
A serious regression in the handling of numeric .Value
was introduced in Helm 2.15.0 (https://github.com/helm/helm/issues/6708).
Document problem and nail travisci to 2.14.3 until a 2.15.x with
a fix is released.