### PR TITLE
fixing timeout

### DIFF
--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -414,11 +414,11 @@ probes:
       timeoutSeconds: 1
   controller:
     livenessProbe:
-      initialDelaySeconds: 5
+      initialDelaySeconds: 10
       periodSeconds: 10
       timeoutSeconds: 1
     readinessProbe:
-      initialDelaySeconds: 5
+      initialDelaySeconds: 10
       periodSeconds: 10
       timeoutSeconds: 1
 


### PR DESCRIPTION
This increases the default limit for initialDelay for kubernetes probing. 