### PR TITLE
make genCerts job not fail if nginx secret already exists

### DIFF
--- a/helm/openwhisk/configMapFiles/genCerts/gencerts.sh
+++ b/helm/openwhisk/configMapFiles/genCerts/gencerts.sh
@@ -15,7 +15,11 @@
 # limitations under the License.
 #
 
-genssl.sh "*.$WHISK_API_HOST_NAME" server /cert-gen
-
-kubectl create secret tls $NGINX_CERT_SECRET --cert=/cert-gen/openwhisk-server-cert.pem --key=/cert-gen/openwhisk-server-key.pem
+if kubectl get secret $NGINX_CERT_SECRET; then
+    echo "using existing $NGINX_CERT_SECRET secret"
+else
+    echo "generating new $NGINX_CERT_SECRET secret"
+    genssl.sh "*.$WHISK_API_HOST_NAME" server /cert-gen
+    kubectl create secret tls $NGINX_CERT_SECRET --cert=/cert-gen/openwhisk-server-cert.pem --key=/cert-gen/openwhisk-server-key.pem
+fi
 

--- a/helm/openwhisk/templates/init-role.yaml
+++ b/helm/openwhisk/templates/init-role.yaml
@@ -25,5 +25,5 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets", "configmaps"]
-  verbs: ["create"]
+  verbs: ["create", "get"]
 


### PR DESCRIPTION
Only create the tls secret if it doesn't already exist.
This avoids repeated job failures if the chart is being
deployed multiple times in the same namespace without
the namespace thoroughly cleaned.