### PR TITLE
fix ingress/nginx misconfiguration

### DIFF
--- a/helm/openwhisk/templates/nginx-cm.yaml
+++ b/helm/openwhisk/templates/nginx-cm.yaml
@@ -45,9 +45,7 @@ data:
       proxy_set_header Connection "";
 
       server {
-{{- if eq .Values.whisk.ingress.type "LoadBalancer" }}
         listen 80;
-{{- end }}
         listen 443 default ssl;
 
         # match namespace, note while OpenWhisk allows a richer character set for a


### PR DESCRIPTION
nginx should be listening on port 80 (http) unconditionally because
port 80 is being used for internally communication (eg ingress to nginx).