### PR TITLE
Instructions for a handmade kubernetes cluster in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ document the necessary steps.
 * [Prerequisites: Kubernetes and Helm](#prerequisites-kubernetes-and-helm)
 * [Deploying OpenWhisk](#deploying-openwhisk)
 * [Administering OpenWhisk](#administering-openwhisk)
-* [Development and Testing](#development-and-testing)
+* [Development and Testing OpenWhisk on Kubernetes](#development-and-testing-openwhisk-on-kubernetes)
 * [Cleanup](#cleanup)
 * [Issues](#issues)
 

--- a/README.md
+++ b/README.md
@@ -129,86 +129,8 @@ significantly larger clusters by scaling up the replica count of the
 various components and labeling multiple nodes as invoker nodes.
 There are some additional notes [here](docs/k8s-diy.md).
 
-#### Kubernetes cluster example with Ubuntu
-You can easily build a cluster using kubeadm and kubectl on Ubuntu 18.04. 
+[Here](docs/k8s-diy-ubuntu.md) a Kubernetes cluster example using kubeadm and Ubuntu 18.04.
 
-Perform these steps on **all the machines** that will be part of your cluster.
-
-First, have Docker installed:
-``` 
-sudo apt-get install -y docker.io 
-```
-
-Then install the kubeadm toolbox:
-```
-sudo apt-get update && sudo apt-get install -y apt-transport-https curl
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
-deb https://apt.kubernetes.io/ kubernetes-xenial main
-EOF
-sudo apt-get update
-sudo apt-get install -y kubelet kubeadm kubectl
-sudo apt-mark hold kubelet kubeadm kubectl
-```
-Swap must be disabled for kubelet to run:
-```
-sudo swapoff -a
-```
-Only on the machine designated as **master node**:
-
-Select the IP address to broadcast the Kubernetes API. With ``` ifconfig ``` you can check the IPs of the network interfaces on your master node (with a public IP you can expose the cluster to the internet).
-
-Then run the following line substituting ```<IP-address>``` with your IP.
-```
-sudo kubeadm init --apiserver-advertise-address=<IP-address>
-```
-When it finishes executing, you will find a result similar to this:
-```
-Your Kubernetes control-plane has initialized successfully!
-
-To start using your cluster, you need to run the following as a regular user:
-
-  mkdir -p $HOME/.kube
-  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
-  sudo chown $(id -u):$(id -g) $HOME/.kube/config
-
-You should now deploy a pod network to the cluster.
-Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
-  https://kubernetes.io/docs/concepts/cluster-administration/addons/
-
-Then you can join any number of worker nodes by running the following on each as root:
-
-kubeadm join <IP-address>:6443 --token 29am26.3fw2znktwbbff0we \
-    --discovery-token-ca-cert-hash sha256:eb32f7f58ae6907f26ed5c075ecd4ef6756d832b6c358fd4b2f408e52d18a369
-```
-Now kubeadm set up a cluster with just the master node. Run those 3 instructions to copy the admin.conf file, to connect kubectl to the new cluster.
-
-Then you can checkout your nodes with:
-```
-kubectl get nodes
-
-NAME          STATUS     ROLES    AGE     VERSION
-master-node   NotReady   master   7m25s   v1.17.0
-```
-The node will stay in the **NotReady** status until you apply Pod Networking. With Weave Net run:
-```
-kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
-```
-After a minute the node will be **Ready**. Check the [Weave Net addon](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#install) to know more.
-
-Now you're ready to let other machines join. Use the join command kubeadm printed earlier on them.
-```
-kubeadm join <IP-address>:6443 --token 29am26.3fw2znktwbbff0we \
-    --discovery-token-ca-cert-hash sha256:eb32f7f58ae6907f26ed5c075ecd4ef6756d832b6c358fd4b2f408e52d18a369
-    
-```
-After a node joined give it time to get in the Ready status, then you can check that everything is 
-running with: ```kubectl get all -A```.
-
-Now you have a running cluster with a master node and one or more worker nodes.
-
-Before deploying OpenWhisk, you have to set up [Dynamic Volume
-Provision](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/). For example, you can dynamically provision NFS persistent volumes, setting up an nfs server, a client provisioner and a storage class. Now you're ready to deploy openwhisk with [Helm](##Helm).
 
 ## Helm
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,86 @@ significantly larger clusters by scaling up the replica count of the
 various components and labeling multiple nodes as invoker nodes.
 There are some additional notes [here](docs/k8s-diy.md).
 
-We would welcome contributions of more detailed DIY instructions.
+#### Kubernetes cluster example with Ubuntu
+You can easily build a cluster using kubeadm and kubectl on Ubuntu 18.04. 
+
+Perform these steps on **all the machines** that will be part of your cluster.
+
+First, have Docker installed:
+``` 
+sudo apt-get install -y docker.io 
+```
+
+Then install the kubeadm toolbox:
+```
+sudo apt-get update && sudo apt-get install -y apt-transport-https curl
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
+deb https://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+sudo apt-get update
+sudo apt-get install -y kubelet kubeadm kubectl
+sudo apt-mark hold kubelet kubeadm kubectl
+```
+Swap must be disabled for kubelet to run:
+```
+sudo swapoff -a
+```
+Only on the machine designated as **master node**:
+
+Select the IP address to broadcast the Kubernetes API. With ``` ifconfig ``` you can check the IPs of the network interfaces on your master node (with a public IP you can expose the cluster to the internet).
+
+Then run the following line substituting ```<IP-address>``` with your IP.
+```
+sudo kubeadm init --apiserver-advertise-address=<IP-address>
+```
+When it finishes executing, you will find a result similar to this:
+```
+Your Kubernetes control-plane has initialized successfully!
+
+To start using your cluster, you need to run the following as a regular user:
+
+  mkdir -p $HOME/.kube
+  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+  sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+You should now deploy a pod network to the cluster.
+Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
+  https://kubernetes.io/docs/concepts/cluster-administration/addons/
+
+Then you can join any number of worker nodes by running the following on each as root:
+
+kubeadm join <IP-address>:6443 --token 29am26.3fw2znktwbbff0we \
+    --discovery-token-ca-cert-hash sha256:eb32f7f58ae6907f26ed5c075ecd4ef6756d832b6c358fd4b2f408e52d18a369
+```
+Now kubeadm set up a cluster with just the master node. Run those 3 instructions to copy the admin.conf file, to connect kubectl to the new cluster.
+
+Then you can checkout your nodes with:
+```
+kubectl get nodes
+
+NAME          STATUS     ROLES    AGE     VERSION
+master-node   NotReady   master   7m25s   v1.17.0
+```
+The node will stay in the **NotReady** status until you apply Pod Networking. With Weave Net run:
+```
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+```
+After a minute the node will be **Ready**. Check the [Weave Net addon](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#install) to know more.
+
+Now you're ready to let other machines join. Use the join command kubeadm printed earlier on them.
+```
+kubeadm join <IP-address>:6443 --token 29am26.3fw2znktwbbff0we \
+    --discovery-token-ca-cert-hash sha256:eb32f7f58ae6907f26ed5c075ecd4ef6756d832b6c358fd4b2f408e52d18a369
+    
+```
+After a node joined give it time to get in the Ready status, then you can check that everything is 
+running with: ```kubectl get all -A```.
+
+Now you have a running cluster with a master node and one or more worker nodes.
+
+Before deploying OpenWhisk, you have to set up [Dynamic Volume
+Provision](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/). For example, you can dynamically provision NFS persistent volumes, setting up an nfs server, a client provisioner and a storage class. Now you're ready to deploy openwhisk with [Helm](##Helm).
 
 ## Helm
 

--- a/docs/k8s-diy-ubuntu.md
+++ b/docs/k8s-diy-ubuntu.md
@@ -1,12 +1,31 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 # Kubernetes cluster example with Ubuntu
 
-You can easily build a cluster using kubeadm and kubectl on Ubuntu 18.04. 
+You can easily build a cluster using kubeadm and kubectl on Ubuntu 18.04.
 
 ### Perform these steps on **all the machines** that will be part of your cluster.
 
 First, have Docker installed:
-``` 
-sudo apt-get install -y docker.io 
+```
+sudo apt-get install -y docker.io
 ```
 
 Then install the kubeadm toolbox:
@@ -72,9 +91,9 @@ Now you're ready to let other machines join. Use the join command kubeadm printe
 ```
 kubeadm join <IP-address>:6443 --token 29am26.3fw2znktwbbff0we \
     --discovery-token-ca-cert-hash sha256:eb32f7f58ae6907f26ed5c075ecd4ef6756d832b6c358fd4b2f408e52d18a369
-    
+
 ```
-After a node joined give it time to get in the Ready status, then you can check that everything is 
+After a node joined give it time to get in the Ready status, then you can check that everything is
 running with: ```kubectl get all -A```.
 
 Now you have a running cluster with a master node and one or more worker nodes.

--- a/docs/k8s-diy-ubuntu.md
+++ b/docs/k8s-diy-ubuntu.md
@@ -1,0 +1,84 @@
+# Kubernetes cluster example with Ubuntu
+
+You can easily build a cluster using kubeadm and kubectl on Ubuntu 18.04. 
+
+### Perform these steps on **all the machines** that will be part of your cluster.
+
+First, have Docker installed:
+``` 
+sudo apt-get install -y docker.io 
+```
+
+Then install the kubeadm toolbox:
+```
+sudo apt-get update && sudo apt-get install -y apt-transport-https curl
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.list
+deb https://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+sudo apt-get update
+sudo apt-get install -y kubelet kubeadm kubectl
+sudo apt-mark hold kubelet kubeadm kubectl
+```
+
+Swap must be disabled for kubelet to run:
+```
+sudo swapoff -a
+```
+
+### Only on the machine designated as **master node**:
+
+Select the IP address to broadcast the Kubernetes API. With ``` ifconfig ``` you can check the IPs of the network interfaces on your master node (with a public IP you can expose the cluster to the internet).
+
+Then run the following line substituting ```<IP-address>``` with your IP.
+```
+sudo kubeadm init --apiserver-advertise-address=<IP-address>
+```
+When it finishes executing, you will find a result similar to this:
+```
+Your Kubernetes control-plane has initialized successfully!
+
+To start using your cluster, you need to run the following as a regular user:
+
+  mkdir -p $HOME/.kube
+  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+  sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+You should now deploy a pod network to the cluster.
+Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
+  https://kubernetes.io/docs/concepts/cluster-administration/addons/
+
+Then you can join any number of worker nodes by running the following on each as root:
+
+kubeadm join <IP-address>:6443 --token 29am26.3fw2znktwbbff0we \
+    --discovery-token-ca-cert-hash sha256:eb32f7f58ae6907f26ed5c075ecd4ef6756d832b6c358fd4b2f408e52d18a369
+```
+Now kubeadm set up a cluster with just the master node. Run those 3 instructions to copy the admin.conf file, to connect kubectl to the new cluster.
+
+Then you can checkout your nodes with:
+```
+kubectl get nodes
+
+NAME          STATUS     ROLES    AGE     VERSION
+master-node   NotReady   master   7m25s   v1.17.0
+```
+The node will stay in the **NotReady** status until you apply Pod Networking. With Weave Net run:
+```
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+```
+After a minute the node will be **Ready**. Check the [Weave Net addon](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#install) to know more.
+
+Now you're ready to let other machines join. Use the join command kubeadm printed earlier on them.
+```
+kubeadm join <IP-address>:6443 --token 29am26.3fw2znktwbbff0we \
+    --discovery-token-ca-cert-hash sha256:eb32f7f58ae6907f26ed5c075ecd4ef6756d832b6c358fd4b2f408e52d18a369
+    
+```
+After a node joined give it time to get in the Ready status, then you can check that everything is 
+running with: ```kubectl get all -A```.
+
+Now you have a running cluster with a master node and one or more worker nodes.
+
+Before deploying OpenWhisk, you have to set up [Dynamic Volume
+Provision](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/), as the [technical
+requirements](docs/k8s-technical-requirements.md) specify. For example, you can dynamically provision NFS persistent volumes, setting up an nfs server, a client provisioner and a storage class. Now you're ready to deploy openwhisk with [Helm](##Helm).


### PR DESCRIPTION
I updated a dead link in the table of contents and added a subsection in the main readme, for the "Using a Kubernetes cluster you built yourself" section, explaining step by step how to create a simple cluster ready to have openwhisk deployed on.

Perhaps it could have its own md file, with even more information, and have it linked from the main readme.