### PR TITLE
version bump TravisCI config to kind 0.6.1 and helm 3.0.1

### DIFF
--- a/docs/k8s-kind.md
+++ b/docs/k8s-kind.md
@@ -36,7 +36,7 @@ operate a default cluster with two virtual worker nodes.
 
 Download the latest stable release of `kind` for your platform from
 https://github.com/kubernetes-sigs/kind/releases. Our TravisCI testing
-currently uses kind v0.5.1 on an ubuntu 18.04 host.
+currently uses kind v0.6.1 on an ubuntu 18.04 host.
 
 ### Creating the Kubernetes Cluster
 
@@ -47,7 +47,7 @@ requiring `sudo` to gain `root` privileges.
 Create a kind-cluster.yaml to configure your cluster.
 ```yaml
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker

--- a/helm/openwhisk/templates/grafana-pod.yaml
+++ b/helm/openwhisk/templates/grafana-pod.yaml
@@ -24,7 +24,6 @@ metadata:
     name: {{ .Release.Name }}-grafana
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 spec:
-  serviceName: {{ .Release.Name }}-grafana
   replicas: {{ .Values.grafana.replicaCount }}
   selector:
     matchLabels:

--- a/helm/openwhisk/templates/user-events-pod.yaml
+++ b/helm/openwhisk/templates/user-events-pod.yaml
@@ -24,7 +24,6 @@ metadata:
     name: {{ .Release.Name }}-user-events
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 spec:
-  serviceName: {{ .Release.Name }}-user-events
   replicas: {{ .Values.user_events.replicaCount }}
   selector:
     matchLabels:

--- a/tools/travis/run-tests.sh
+++ b/tools/travis/run-tests.sh
@@ -16,12 +16,10 @@
 # limitations under the License.
 #
 
-export KUBECONFIG="$(kind get kubeconfig-path)"
-
 ###
 # Now run the tests provided in the Chart to verify the deployment
 ###
-if helm test ow4travis --timeout 2400; then
+if helm test ow4travis -n openwhisk --timeout 40m; then
     echo "PASSED! Deployment verification tests passed."
 else
     echo "FAILED: Deployment verification tests failed."

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -18,22 +18,31 @@
 
 set -x
 
-# Intall python packages used by box-upload.py
-pip install --user humanize requests
+HELM_VERSION=v3.0.1
+KIND_VERSION=v0.6.1
+KUBECTL_VERSION=v1.16.3
+WSK_CLI_VERSION=latest
 
-# Download and install misc packages and utilities
+# Download and install command line tools
 pushd /tmp
-  # Install kubectl
-  curl -Lo ./kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl
+  # kubectl
+  curl -Lo ./kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
   chmod +x kubectl
   sudo cp kubectl /usr/local/bin/kubectl
 
-  # download and install the wsk cli
-  wget -q https://github.com/apache/openwhisk-cli/releases/download/latest/OpenWhisk_CLI-latest-linux-amd64.tgz
-  tar xzf OpenWhisk_CLI-latest-linux-amd64.tgz
+  # kind
+  curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/$KIND_VERSION/kind-linux-amd64
+  chmod +x kind
+  sudo cp kind /usr/local/bin/kind
+
+  # wsk cli
+  wget -q https://github.com/apache/openwhisk-cli/releases/download/$WSK_CLI_VERSION/OpenWhisk_CLI-$WSK_CLI_VERSION-linux-amd64.tgz
+  tar xzf OpenWhisk_CLI-$WSK_CLI_VERSION-linux-amd64.tgz
   sudo cp wsk /usr/local/bin/wsk
 
-  # Download and install helm 2 (remove tiller init from start-kind.sh when upgrading to helm 3)
-  curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh && chmod +x get_helm.sh && ./get_helm.sh --version v2.16.1
+  # helm3
+  curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get-helm-3 > get-helm-3.sh && chmod +x get-helm-3.sh && ./get-helm-3.sh --version $HELM_VERSION
 popd
 
+# Install additional python packages for box-upload.py
+pip install --user humanize requests

--- a/tools/travis/start-kind.sh
+++ b/tools/travis/start-kind.sh
@@ -18,53 +18,18 @@
 
 set -x
 
-# Install kind
-curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64
-chmod +x kind
-sudo cp kind /usr/local/bin/kind
-
-# Boot kind
+# Create cluster config
 cat > mycluster.yaml <<EOF
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
 - role: worker
 EOF
 
-kind create cluster --config mycluster.yaml --name kind --image kindest/node:${TRAVIS_KUBE_VERSION} --wait 300s
-
-export KUBECONFIG="$(kind get kubeconfig-path)"
+# Boot cluster
+kind create cluster --config mycluster.yaml --name kind --image kindest/node:${TRAVIS_KUBE_VERSION} --wait 10m || exit 1
 
 echo "Kubernetes cluster is deployed and reachable"
 kubectl describe nodes
-
-# Pods running in kube-system namespace should have cluster-admin role
-kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
-
-# Install tiller (Helm2) into the cluster
-/usr/local/bin/helm init --service-account default
-
-# Wait for tiller to be ready
-TIMEOUT=0
-TIMEOUT_COUNT=60
-until [ $TIMEOUT -eq $TIMEOUT_COUNT ]; do
-  TILLER_STATUS=$(kubectl -n kube-system get pods -o wide | grep tiller-deploy | awk '{print $3}')
-  TILLER_READY_COUNT=$(kubectl -n kube-system get pods -o wide | grep tiller-deploy | awk '{print $2}')
-  if [[ "$TILLER_STATUS" == "Running" ]] && [[ "$TILLER_READY_COUNT" == "1/1" ]]; then
-    break
-  fi
-  echo "Waiting for tiller to be ready"
-  kubectl -n kube-system get pods -o wide
-  let TIMEOUT=TIMEOUT+1
-  sleep 5
-done
-
-if [ $TIMEOUT -eq $TIMEOUT_COUNT ]; then
-  echo "Failed to install tiller"
-
-  # Dump diagnostic info to see why tiller failed
-  kubectl -n kube-system describe pods
-  exit 1
-fi


### PR DESCRIPTION
1. Version bump kind and kubectl to maintain currency.

2. Prepare for real conversion to Helm 3 by using
   a Helm v3 CLI to deploy the (unchanged) Helm 2 chart.