### PR TITLE
NetworkPolicy to isolate pods running user actions

### DIFF
--- a/docs/configurationChoices.md
+++ b/docs/configurationChoices.md
@@ -221,6 +221,14 @@ you can set `invoker.containerFactory.networkConfig.dns.inheritInvokerConfig` to
 and explicitly configure the child values of `invoker.containerFactory.networkConfig.dns.overrides`
 instead.
 
+### User action container network isolation
+
+By default, a set of NetworkPolicy objects will be configured to isolate
+pods running user actions from each other and from the back-end pods
+of the OpenWhisk control plane.  If you want to disable this network
+isolation, set `invoker.containerFactory.kubernetes.isolateUserActions`
+to `false`.
+
 ### Customizing probes setting
 
 Many openwhisk components has liveness and readiness probes configured. Sometimes it is observed that components do not come up or in ready state before the probes starts executing which causes pods to restarts or fail. You can configure probes timing settings like `initialDelaySeconds`, `periodSeconds` and `timeoutSeconds` in `mycluster.yaml`

--- a/helm/openwhisk/Chart.yaml
+++ b/helm/openwhisk/Chart.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 description: An open source, distributed serverless platform that executes functions in response to events at any scale
 name: openwhisk
-version: 0.1.10
+version: 0.1.11
 icon: https://raw.githubusercontent.com/apache/openwhisk/682eb5b62ee6ba8017ab54226c2ace3637f4f1ec/docs/images/whisk_icon_full-color_with_tm_64x64-300dpi.png
 keywords:
   - Apache OpenWhisk

--- a/helm/openwhisk/templates/network-policy.yaml
+++ b/helm/openwhisk/templates/network-policy.yaml
@@ -1,0 +1,88 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+{{- if .Values.invoker.containerFactory.kubernetes.isolateUserActions }}
+
+# Default deny all ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-default-no-ingress-np
+  labels:
+{{ include "openwhisk.label_boilerplate" .| indent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+
+# Backend control plane pods only accept connections from non-user-action-pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-backend-np
+  labels:
+{{ include "openwhisk.label_boilerplate" .| indent 4 }}
+spec:
+  podSelector:
+    matchExpressions:
+      - {key: user-action-pod, operator: DoesNotExist}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchExpressions:
+          - {key: user-action-pod, operator: DoesNotExist}
+---
+
+# Frontend pods (nginx, controller, apigateway) accept connections from anyone
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-frontend-np
+  labels:
+{{ include "openwhisk.label_boilerplate" .| indent 4 }}
+spec:
+  podSelector:
+    matchExpressions:
+      - {key: name, operator: In, values: ["{{ .Release.Name }}-controller", "{{ .Release.Name }}-apigateway", "{{ .Release.Name }}-nginx"]}
+  policyTypes:
+  - Ingress
+  ingress:
+  - {}
+---
+
+# User action pods will only accept connections from invokers
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-actions-allow-invoker-np
+  labels:
+{{ include "openwhisk.label_boilerplate" .| indent 4 }}
+spec:
+  podSelector:
+    matchExpressions:
+      - {key: user-action-pod, operator: In, values: ["true"]}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          name: {{ .Release.Name }}-invoker
+{{- end }}

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -128,9 +128,9 @@ whisk:
     includeSystemTests: false
   versions:
     openwhisk:
-      buildDate: "2019-12-20-17:00:07Z"
-      buildNo: "20191220a"
-      gitTag: "8eb922f568d7843cdb1068252d29ba5723b30283"
+      buildDate: "2020-02-14-00:17:46Z"
+      buildNo: "20200214a"
+      gitTag: "84e53daa3b9e7ecb65b106ef432f4ead8f2cb9f2"
     openwhiskCli:
       tag: "1.0.0"
     openwhiskCatalog:
@@ -153,7 +153,7 @@ k8s:
 # Images used to run auxillary tasks/jobs
 utility:
   imageName: "openwhisk/ow-utils"
-  imageTag: "8eb922f"
+  imageTag: "84e53da"
   imagePullPolicy: "IfNotPresent"
 
 # Docker registry
@@ -237,7 +237,7 @@ nginx:
 # Controller configurations
 controller:
   imageName: "openwhisk/controller"
-  imageTag: "8eb922f"
+  imageTag: "84e53da"
   imagePullPolicy: "IfNotPresent"
   replicaCount: 1
   restartPolicy: "Always"
@@ -249,7 +249,7 @@ controller:
 # Invoker configurations
 invoker:
   imageName: "openwhisk/invoker"
-  imageTag: "8eb922f"
+  imageTag: "84e53da"
   imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
   port: 8080
@@ -271,6 +271,7 @@ invoker:
           search: ""
           options: ""
     kubernetes:
+      isolateUserActions: true
       replicaCount: 1
 
 # API Gateway configurations
@@ -301,7 +302,7 @@ redis:
 # User-events configuration
 user_events:
   imageName: "openwhisk/user-events"
-  imageTag: "8eb922f"
+  imageTag: "84e53da"
   imagePullPolicy: "IfNotPresent"
   replicaCount: 1
   restartPolicy: "Always"


### PR DESCRIPTION
Add NetworkPolicy to enforce moderate levels of network isolation:
  1. User action pods only accept incoming connections from invokers
  2. Back-end control plane pods only accept incoming connections
     from other control plane pods.