### PR TITLE
Update k8s-aws.md

### DIFF
--- a/docs/k8s-aws.md
+++ b/docs/k8s-aws.md
@@ -73,17 +73,7 @@ whisk:
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
       service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:iam::12345678901:server-certificate/ow-self-signed
-
-k8s:
-  persistence:
-    enabled: false
 ```
-
-For ease of deployment, you should disable persistent volumes because
-EKS does not come with an automatically configured default
-StorageClass. Alternatively, you may choose to leave persistence
-enabled and manually create the necessary persistent volumes using
-AWS/EKS instructions to do so.
 
 Shortly after you deploy your helm chart, an ELB should be
 automatically created. You can determine its hostname by issuing
@@ -99,10 +89,6 @@ errors from `wsk` when attempting to access it.
 ## Hints and Tips
 
 ## Limitations
-
-Without additional configuration to enable persistent volumes, EKS is
-only appropriate for development and testing purposes.  It is not
-recommended for production deployments of OpenWhisk.
 
 If you used a self-signed certificate, you will need to invoke `wsk`
 with the `-i` command line argument to bypass certificate checking.


### PR DESCRIPTION
Since EKS 1.11 which is the oldest you can deploy there has been support for default storageclasses (https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html)
As such I propose we remove the stuff about PVCs because with it enabled it allocates volumes just fine.

```
MT-109900:openwhisk-deploy-kube barber$ kubectl -n openwhisk get pvc
NAME                                            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
owdev-alarmprovider-pvc                         Bound    pvc-ec746f3d-5e28-11ea-84b0-0241f8e4fa45   1Gi        RWO            gp2            92s
owdev-cloudantprovider-pvc                      Bound    pvc-ec746f60-5e28-11ea-84b0-0241f8e4fa45   1Gi        RWO            gp2            92s
owdev-kafka-pvc-owdev-kafka-0                   Bound    pvc-ec86d87f-5e28-11ea-bbc7-12b20bb5dcf3   1Gi        RWO            gp2            92s
owdev-kafka-pvc-owdev-kafka-1                   Bound    pvc-ec8ef2da-5e28-11ea-bbc7-12b20bb5dcf3   1Gi        RWO            gp2            92s
owdev-kafka-pvc-owdev-kafka-2                   Bound    pvc-ec93eb7f-5e28-11ea-bbc7-12b20bb5dcf3   1Gi        RWO            gp2            92s
owdev-redis-pvc                                 Bound    pvc-ec746f1c-5e28-11ea-84b0-0241f8e4fa45   1Gi        RWO            gp2            92s
owdev-zookeeper-pvc-data-owdev-zookeeper-0      Bound    pvc-ec999050-5e28-11ea-bbc7-12b20bb5dcf3   1Gi        RWO            gp2            92s
owdev-zookeeper-pvc-data-owdev-zookeeper-1      Bound    pvc-ec9dab99-5e28-11ea-bbc7-12b20bb5dcf3   1Gi        RWO            gp2            92s
owdev-zookeeper-pvc-data-owdev-zookeeper-2      Bound    pvc-eca29169-5e28-11ea-bbc7-12b20bb5dcf3   1Gi        RWO            gp2            91s
owdev-zookeeper-pvc-datalog-owdev-zookeeper-0   Bound    pvc-ec9ac155-5e28-11ea-bbc7-12b20bb5dcf3   1Gi        RWO            gp2            92s
owdev-zookeeper-pvc-datalog-owdev-zookeeper-1   Bound    pvc-ec9effad-5e28-11ea-bbc7-12b20bb5dcf3   1Gi        RWO            gp2            92s
owdev-zookeeper-pvc-datalog-owdev-zookeeper-2   Bound    pvc-eca39c36-5e28-11ea-bbc7-12b20bb5dcf3   1Gi        RWO            gp2            91s
```