### PR TITLE
Update test command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ replaced by the values returned by `wsk property get --apihost` and
 `wsk property get --auth` respectively.
 ```shell
 cd $OPENWHISK_HOME
-./gradlew :tests:testSystemBasic -Dwhisk.auth=$WHISK_AUTH -Dwhisk.server=https://$WHISK_SERVER -Dopenwhisk.home=`pwd`
+./gradlew :tests:testSystemKCF -Dwhisk.auth=$WHISK_AUTH -Dwhisk.server=https://$WHISK_SERVER -Dopenwhisk.home=`pwd`
 ```
 You can also launch the system tests as JUnit test from an IDE by
 adding the same system properties to the JVM command line used to


### PR DESCRIPTION
In this PR (https://github.com/apache/openwhisk/pull/4777) ActivationLogsTests are excluded when testing against kubernetes container factory. But the test command here does not reflect this change.