### PR TITLE
Support external kafka zookeeper

### DIFF
--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -66,30 +66,36 @@ app: {{ template "openwhisk.fullname" . }}
 
 {{/* client connection string for zookeeper cluster (server1:port,server2:port, ... serverN:port)*/}}
 {{- define "openwhisk.zookeeper_connect" -}}
+{{- if .Values.zookeeper.external -}}
+{{ .Values.zookeeper.host }}:{{ .Values.zookeeper.port }}
+{{- else -}}
 {{- $zkname := printf "%s-zookeeper" .Release.Name }}
 {{- $zkport := .Values.zookeeper.port }}
 {{- $kubeDomain := .Values.k8s.domain }}
 {{- range $i, $e := until (int .Values.zookeeper.replicaCount) -}}{{ if ne $i 0 }},{{ end }}{{ $zkname }}-{{ . }}.{{ $zkname }}.{{ $.Release.Namespace }}.svc.{{ $kubeDomain }}:{{ $zkport }}{{ end }}
 {{- end -}}
+{{- end -}}
 
 {{/* host name for server.0 in zookeeper cluster */}}
 {{- define "openwhisk.zookeeper_zero_host" -}}
+{{- if .Values.zookeeper.external -}}
+{{ .Values.zookeeper.host }}
+{{- else -}}
 {{- $zkname := printf "%s-zookeeper" .Release.Name }}
 {{ $zkname }}-0.{{ $zkname }}.{{ $.Release.Namespace }}.svc.{{ .Values.k8s.domain }}
+{{- end -}}
 {{- end -}}
 
 {{/* client connection string for kafka cluster (server1:port,server2:port, ... serverN:port)*/}}
 {{- define "openwhisk.kafka_connect" -}}
+{{- if .Values.kafka.external -}}
+{{ .Values.kafka.host }}:{{ .Values.kafka.port }}
+{{- else -}}
 {{- $kname := printf "%s-kafka" .Release.Name }}
 {{- $kport := .Values.kafka.port }}
 {{- $kubeDomain := .Values.k8s.domain }}
 {{- range $i, $e := until (int .Values.kafka.replicaCount) -}}{{ if ne $i 0 }},{{ end }}{{ $kname }}-{{ . }}.{{ $kname }}.{{ $.Release.Namespace }}.svc.{{ $kubeDomain }}:{{ $kport }}{{ end }}
 {{- end -}}
-
-{{/* host name for server.0 in kafka cluster */}}
-{{- define "openwhisk.kafka_zero_host" -}}
-{{- $kname := printf "%s-kafka" .Release.Name }}
-{{ $kname }}-0.{{ $kname }}.{{ $.Release.Namespace }}.svc.{{ .Values.k8s.domain }}
 {{- end -}}
 
 {{/* Runtimes manifest */}}

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -67,7 +67,7 @@ app: {{ template "openwhisk.fullname" . }}
 {{/* client connection string for zookeeper cluster (server1:port,server2:port, ... serverN:port)*/}}
 {{- define "openwhisk.zookeeper_connect" -}}
 {{- if .Values.zookeeper.external -}}
-{{ .Values.zookeeper.host }}:{{ .Values.zookeeper.port }}
+{{ .Values.zookeeper.connect_string }}
 {{- else -}}
 {{- $zkname := printf "%s-zookeeper" .Release.Name }}
 {{- $zkport := .Values.zookeeper.port }}
@@ -89,7 +89,7 @@ app: {{ template "openwhisk.fullname" . }}
 {{/* client connection string for kafka cluster (server1:port,server2:port, ... serverN:port)*/}}
 {{- define "openwhisk.kafka_connect" -}}
 {{- if .Values.kafka.external -}}
-{{ .Values.kafka.host }}:{{ .Values.kafka.port }}
+{{ .Values.kafka.connect_string }}
 {{- else -}}
 {{- $kname := printf "%s-kafka" .Release.Name }}
 {{- $kport := .Values.kafka.port }}

--- a/helm/openwhisk/templates/kafka-pdb.yaml
+++ b/helm/openwhisk/templates/kafka-pdb.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{- if and .Values.pdb.enable (gt (int .Values.kafka.replicaCount) 1) }}
+{{- if and .Values.pdb.enable (gt (int .Values.kafka.replicaCount) 1) (not .Values.kafka.external) }}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/helm/openwhisk/templates/kafka-pod.yaml
+++ b/helm/openwhisk/templates/kafka-pod.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{- if not .Values.controller.lean }}
+{{- if and (not .Values.controller.lean) (not .Values.kafka.external) }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/helm/openwhisk/templates/kafka-pvc.yaml
+++ b/helm/openwhisk/templates/kafka-pvc.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{ if and .Values.k8s.persistence.enabled (eq (int .Values.kafka.replicaCount) 1 ) (not .Values.controller.lean) }}
+{{ if and .Values.k8s.persistence.enabled (eq (int .Values.kafka.replicaCount) 1 ) (not .Values.controller.lean) (not .Values.kafka.external) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/openwhisk/templates/kafka-svc.yaml
+++ b/helm/openwhisk/templates/kafka-svc.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{- if not .Values.controller.lean }}
+{{- if and (not .Values.controller.lean) (not .Values.kafka.external) }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/openwhisk/templates/zookeeper-cm.yaml
+++ b/helm/openwhisk/templates/zookeeper-cm.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{- if not .Values.controller.lean }}
+{{- if add (not .Values.controller.lean) (not .Values.zookeeper.external) }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm/openwhisk/templates/zookeeper-pdb.yaml
+++ b/helm/openwhisk/templates/zookeeper-pdb.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{- if and .Values.pdb.enable (gt (int .Values.zookeeper.replicaCount) 1) }}
+{{- if and .Values.pdb.enable (gt (int .Values.zookeeper.replicaCount) 1) (not .Values.zookeeper.external) }}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/helm/openwhisk/templates/zookeeper-pod.yaml
+++ b/helm/openwhisk/templates/zookeeper-pod.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{- if not .Values.controller.lean }}
+{{- if and (not .Values.controller.lean) (not .Values.zookeeper.external) }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/helm/openwhisk/templates/zookeeper-pvc-data.yaml
+++ b/helm/openwhisk/templates/zookeeper-pvc-data.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{ if and .Values.k8s.persistence.enabled (eq (int .Values.zookeeper.replicaCount) 1 ) }}
+{{ if and .Values.k8s.persistence.enabled (eq (int .Values.zookeeper.replicaCount) 1 ) (not .Values.zookeeper.external) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/openwhisk/templates/zookeeper-pvc-datalog.yaml
+++ b/helm/openwhisk/templates/zookeeper-pvc-datalog.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{ if and .Values.k8s.persistence.enabled (eq (int .Values.zookeeper.replicaCount) 1 ) }}
+{{ if and .Values.k8s.persistence.enabled (eq (int .Values.zookeeper.replicaCount) 1 ) (not .Values.zookeeper.external) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/openwhisk/templates/zookeeper-svc.yaml
+++ b/helm/openwhisk/templates/zookeeper-svc.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{- if not .Values.controller.lean }}
+{{- if and (not .Values.controller.lean) (not .Values.zookeeper.external) }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -174,6 +174,7 @@ zookeeper:
   # Note: Zookeeper's quorum protocol is designed to have an odd number of replicas.
   replicaCount: 1
   restartPolicy: "Always"
+  connect_string: null
   host: null
   port: 2181
   serverPort: 2888
@@ -196,7 +197,7 @@ kafka:
   imagePullPolicy: "IfNotPresent"
   replicaCount: 1
   restartPolicy: "Always"
-  host: null
+  connect_string: null
   port: 9092
   persistence:
     size: 512Mi

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -167,12 +167,14 @@ docker:
 
 # zookeeper configurations
 zookeeper:
+  external: false
   imageName: "zookeeper"
   imageTag: "3.4"
   imagePullPolicy: "IfNotPresent"
   # Note: Zookeeper's quorum protocol is designed to have an odd number of replicas.
   replicaCount: 1
   restartPolicy: "Always"
+  host: null
   port: 2181
   serverPort: 2888
   leaderElectionPort: 3888
@@ -188,11 +190,13 @@ zookeeper:
 
 # kafka configurations
 kafka:
+  external: false
   imageName: "wurstmeister/kafka"
   imageTag: "2.12-2.3.1"
   imagePullPolicy: "IfNotPresent"
   replicaCount: 1
   restartPolicy: "Always"
+  host: null
   port: 9092
   persistence:
     size: 512Mi


### PR DESCRIPTION
- [x] support external kafka/zookeeper.

If want to support external kafka/zookeeper, just add below configuration to mycluster.yaml, e.g.
```
zookeeper:
  external: true
  connect_string: xxx,xxx,xxx,xxx:2181,xxx.xxx.xxx.xxx:2182,xxx.xxx.xxx.xxx:2183
  host: xxx.xxx.xxx.xxx

kafka:
  external: true
  connect_string: xxx.xxx.xxx.xxx:9093,xxx.xxx.xxx.xxx:9094,xxx.xxx.xxx.xxx:9095
```
I tested in my local, works well