### PR TITLE
Fix issue with quoted docker registry credentials

### DIFF
--- a/helm/openwhisk/configMapFiles/dockerPullRuntimes/playbook.yml
+++ b/helm/openwhisk/configMapFiles/dockerPullRuntimes/playbook.yml
@@ -25,8 +25,8 @@
     docker_pull_retries: 10
     docker_pull_delay: 10
     runtimes_registry: "{{ lookup('env', 'RUNTIMES_REGISTRY') | default() }}"
-    runtimes_registry_username: "{{ lookup('env', 'RUNTIMES_REGISTRY_USERNAME') | default() }}"
-    runtimes_registry_password: "{{ lookup('env', 'RUNTIMES_REGISTRY_PASSWORD') | default() }}"
+    runtimes_registry_username: "{{ lookup('env', 'RUNTIMES_REGISTRY_USERNAME') | default() | regex_replace('^\"|\"$', '') }}"
+    runtimes_registry_password: "{{ lookup('env', 'RUNTIMES_REGISTRY_PASSWORD') | default() | regex_replace('^\"|\"$', '') }}"
     runtimes_manifest: "{{ lookup('env', 'RUNTIMES_MANIFEST') }}"
     runtimes_manifest_json: "{{ lookup('env', 'RUNTIMES_MANIFEST') | from_json }}"
 


### PR DESCRIPTION
The docker registry credentials are quoted here:
https://github.com/apache/openwhisk-deploy-kube/blob/bbf7846517ed690bb0bf2fdda444222a82037aa8/helm/openwhisk/templates/ow-docker-registry-secret.yaml#L26-L27

When used in the dockerPullRuntimes Ansible, literal quotes are passed in the username and password, breaking authentication.

This fixes that by stripping these before use.