### PR TITLE
Add flexibility to configure grafana

### DIFF
--- a/helm/openwhisk/templates/grafana-deploy.yaml
+++ b/helm/openwhisk/templates/grafana-deploy.yaml
@@ -64,18 +64,12 @@ spec:
         - name: grafana
           image: "{{- .Values.docker.registry.name -}}{{- .Values.grafana.imageName -}}:{{- .Values.grafana.imageTag -}}"
           env:
-          - name: "GF_AUTH_ANONYMOUS_ENABLED"
-            value: "true"
           - name: "GF_SECURITY_ADMIN_PASSWORD"
             value: {{ .Values.grafana.adminPassword }}
-          - name: "GF_PATHS_PROVISIONING"
-            value: "/var/lib/grafana/config"
-          - name: "GF_USERS_ALLOW_SIGN_UP"
-            value: "false"
-          - name: "GF_SERVER_ROOT_URL"
-            value: "%(protocol)s://%(domain)s/monitoring"
-          - name: "GF_SERVER_SERVE_FROM_SUB_PATH"
-            value: "true"
+          {{- range .Values.grafana.env }}
+          - name: {{ .name }}
+            value: {{ .value | quote }}
+          {{- end }}
 
           ports:
             - containerPort: {{ .Values.grafana.port }}

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -335,6 +335,18 @@ grafana:
   - https://raw.githubusercontent.com/apache/openwhisk/master/core/monitoring/user-events/compose/grafana/dashboards/openwhisk_events.json
   - https://raw.githubusercontent.com/apache/openwhisk/master/core/monitoring/user-events/compose/grafana/dashboards/global-metrics.json
   - https://raw.githubusercontent.com/apache/openwhisk/master/core/monitoring/user-events/compose/grafana/dashboards/top-namespaces.json
+  # https://grafana.com/docs/grafana/latest/administration/configuration/#configure-with-environment-variables
+  env:
+  - name: "GF_AUTH_ANONYMOUS_ENABLED"
+    value: "true"
+  - name: "GF_PATHS_PROVISIONING"
+    value: "/var/lib/grafana/config"
+  - name: "GF_USERS_ALLOW_SIGN_UP"
+    value: "false"
+  - name: "GF_SERVER_ROOT_URL"
+    value: "%(protocol)s://%(domain)s/monitoring"
+  - name: "GF_SERVER_SERVE_FROM_SUB_PATH"
+    value: "true"
 
 # Metrics
 metrics:


### PR DESCRIPTION
# Context

I am experimenting with Openwhisk and Openstack and currently using _kubectl proxy_ to access the dashboard. However, for that to work, I have two options:

1. Change de variable on the fly:
`kubectl -n openwhisk set env deployment/owdev-grafana GF_SERVER_ROOT_URL=http://localhost:8001/api/v1/namespaces/openwhisk/services/http:owdev-grafana:http/proxy/`

2. Replace the value in the manifest before installing the chart.

# What would you expect?

To be able not only to set GF_SERVER_ROOT_URL but any other environment variable in the configuration file.

`helm install owdev openwhisk/helm/openwhisk -n openwhisk --create-namespace -f mycluster.yaml`