### PR TITLE
don't quote username/password before piping to b64enc

### DIFF
--- a/helm/openwhisk/templates/ow-docker-registry-secret.yaml
+++ b/helm/openwhisk/templates/ow-docker-registry-secret.yaml
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+{{- if ne .Values.docker.registry.name "" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,5 +24,6 @@ metadata:
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 type: Opaque
 data:
-  docker_registry_username: {{ .Values.docker.registry.username | quote | b64enc }}
-  docker_registry_password: {{ .Values.docker.registry.password | quote | b64enc }}
+  docker_registry_username: {{ .Values.docker.registry.username | b64enc }}
+  docker_registry_password: {{ .Values.docker.registry.password | b64enc }}
+{{- end -}}


### PR DESCRIPTION
An alternate fix to that proposed in #613 to avoid adding
quotes around the docker registry username/password.