### PR TITLE
Support externel nginx cerficate

### DIFF
--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -327,3 +327,17 @@ imagePullSecrets:
 {{- define "openwhisk.grafana_host" -}}
 {{ .Release.Name }}-grafana.{{ .Release.Namespace }}.svc.{{ .Values.k8s.domain }}
 {{- end -}}
+
+{{/* nginx cert */}}
+{{- define "openwhisk.nginx_cert" -}}
+{{- if .Values.nginx.certificate.external }}
+{{ .Files.Get .Values.nginx.certificate.cert_file }}
+{{- end -}}
+{{- end -}}
+
+{{/* nginx key */}}
+{{- define "openwhisk.nginx_key" -}}
+{{- if .Values.nginx.certificate.external }}
+{{ .Files.Get .Values.nginx.certificate.key_file }}
+{{- end -}}
+{{- end -}}

--- a/helm/openwhisk/templates/gen-certs-cm.yaml
+++ b/helm/openwhisk/templates/gen-certs-cm.yaml
@@ -22,4 +22,13 @@ metadata:
   labels:
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 data:
+{{- if .Values.nginx.certificate.external }}
+  tls.crt: |
+{{ include "openwhisk.nginx_cert" . | indent 4 }}
+  tls.key: |
+{{ include "openwhisk.nginx_key" . | indent 4 }}
+  sslPassword: |
+    {{ .Values.nginx.certificate.sslPassword }}
+{{- else }}
 {{ (.Files.Glob "configMapFiles/genCerts/gencerts.sh").AsConfig | indent 2 }}
+{{- end }}

--- a/helm/openwhisk/templates/gen-certs-job.yaml
+++ b/helm/openwhisk/templates/gen-certs-job.yaml
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+{{- if not .Values.nginx.certificate.external }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -55,3 +56,4 @@ spec:
             configMapKeyRef:
               name: {{ .Release.Name }}-whisk.config
               key: whisk_api_host_name
+{{- end }}

--- a/helm/openwhisk/templates/nginx-cm.yaml
+++ b/helm/openwhisk/templates/nginx-cm.yaml
@@ -57,6 +57,11 @@ data:
         ssl_session_timeout  10m;
         ssl_certificate      /etc/nginx/certs/tls.crt;
         ssl_certificate_key  /etc/nginx/certs/tls.key;
+        {{- if .Values.nginx.certificate.external }}
+        {{- if ne .Values.nginx.certificate.sslPassword "" }}
+        ssl_password_file "/etc/nginx/certs/sslPassword";
+        {{- end }}
+        {{- end }}
         ssl_verify_client off;
         ssl_protocols        TLSv1.2;
         ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256;

--- a/helm/openwhisk/templates/nginx-pod.yaml
+++ b/helm/openwhisk/templates/nginx-pod.yaml
@@ -48,9 +48,15 @@ spec:
       {{- end }}
 
       volumes:
+      {{- if .Values.nginx.certificate.external }}
+      - name: nginx-certs
+        configMap:
+          name: {{ .Release.Name }}-gen-certs
+      {{- else }}
       - name: nginx-certs
         secret:
           secretName: {{ .Release.Name }}-nginx
+      {{- end }}
       - name: nginx-conf
         configMap:
           name: {{ .Release.Name }}-nginx

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -239,7 +239,7 @@ nginx:
   httpPort: 80
   httpsPort: 443
   httpsNodePort: 31001
-  certifiate:
+  certificate:
     external: false
     cert_file: ""
     key_file: ""

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -239,6 +239,11 @@ nginx:
   httpPort: 80
   httpsPort: 443
   httpsNodePort: 31001
+  certifiate:
+    external: false
+    cert_file: ""
+    key_file: ""
+    sslPassword: ""
 
 # Controller configurations
 controller:


### PR DESCRIPTION
- [x] Support externel nginx cerficate
       Currently, system provides a self-signed certificates which would not for production, i think need to support `user's own nginx certifcate` for production. e.g.

```
nginx:
  httpsNodePort: 31001
  certificate:
    external: true
    cert_file: "$cert_file_path"
    key_file: "$key_file_path"
    sslPassword: "xxx"
```
If want to use default self-signed certificates, just change 
```
nginx:
  certificate:
    external: false
```