### PR TITLE
Add elasticsearch

### DIFF
--- a/docs/configurationChoices.md
+++ b/docs/configurationChoices.md
@@ -97,6 +97,48 @@ redis:
   port: <redis port>
 ```
 
+### Using an external kafka/zookeeper
+
+To use an externally deployed kafka/zookeeper instead of using default single pod deployment, add a stanza like the one
+below to your `mycluster.yaml`, substituting in the appropriate values
+for `<...>`
+
+```yaml
+zookeeper:
+  external: true
+  connect_string: <zookeeper connect string>
+  host: <the first instance of zookeeper>
+
+kafka:
+  external: true
+  connect_string: <kafka connect string>
+```
+
+### Using activation store backend: ElasticSearch
+
+Currently, deploy-kube uses `CouchDB` for activation store backend by default,
+If you want to change it to `ElasticSearch`, just change
+
+```yaml
+activationStoreBackend: "ElasticSearch"
+```
+
+If you want to use an externally deployed ElasticSearch for activation store backend, add a stanza like the one
+below to your `mycluster.yaml`, substituting in the appropriate values
+for `<...>`
+
+```yaml
+activationStoreBackend: "ElasticSearch"
+elasticsearch:
+  external: true
+  connect_string: <elasticsearch connect string>
+  protocol: <"http" or "https">
+  host: <the first instance of elasticsearch>
+  indexPattern: <the indexPattern for activation index>
+  username: <elasticsearch username>
+  password: <elasticsearch username>
+```
+
 ### Persistence
 
 Several of the OpenWhisk components that are deployed by the Helm

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -55,6 +55,10 @@ app: {{ template "openwhisk.fullname" . }}
 {{ .Values.db.auth.username }}:{{ .Values.db.auth.password }}
 {{- end -}}
 
+{{- define "openwhisk.elasticsearch_authentication" -}}
+{{ .Values.username }}:{{ .Values.password }}
+{{- end -}}
+
 {{/* hostname for redis */}}
 {{- define "openwhisk.redis_host" -}}
 {{- if .Values.redis.external -}}

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -429,3 +429,14 @@ Return the appropriate apiVersion for ingress.
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "openwhisk.elasticsearch_connect" -}}
+{{- if .Values.elasticsearch.external -}}
+{{ .Values.elasticsearch.connect_string }}
+{{- else -}}
+{{- $kname := printf "%s-elasticsearch" .Release.Name }}
+{{- $kport := .Values.httpPort }}
+{{- $kubeDomain := .Values.k8s.domain }}
+{{- range $i, $e := until (int .Values.replicas) -}}{{ if ne $i 0 }},{{ end }}{{ $kname }}-{{ . }}.{{ $kname }}.{{ $.Release.Namespace }}.svc.{{ $kubeDomain }}:{{ $kport }}{{ end }}
+{{- end -}}
+{{- end -}}

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -56,7 +56,7 @@ app: {{ template "openwhisk.fullname" . }}
 {{- end -}}
 
 {{- define "openwhisk.elasticsearch_authentication" -}}
-{{ .Values.username }}:{{ .Values.password }}
+{{ .Values.elasticsearch.username }}:{{ .Values.elasticsearch.password }}
 {{- end -}}
 
 {{/* hostname for redis */}}
@@ -351,7 +351,7 @@ imagePullSecrets:
 Expand the name of the chart.
 */}}
 {{- define "elasticsearch.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.elasticsearch.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -359,40 +359,40 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "elasticsearch.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := default .Chart.Name .Values.elasticsearch.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "elasticsearch.uname" -}}
-{{- if empty .Values.fullnameOverride -}}
-{{- if empty .Values.nameOverride -}}
-{{ .Values.clusterName }}-{{ .Values.nodeGroup }}
+{{- if empty .Values.elasticsearch.fullnameOverride -}}
+{{- if empty .Values.elasticsearch.nameOverride -}}
+{{ .Values.elasticsearch.clusterName }}-{{ .Values.elasticsearch.nodeGroup }}
 {{- else -}}
-{{ .Values.nameOverride }}-{{ .Values.nodeGroup }}
+{{ .Values.elasticsearch.nameOverride }}-{{ .Values.elasticsearch.nodeGroup }}
 {{- end -}}
 {{- else -}}
-{{ .Values.fullnameOverride }}
+{{ .Values.elasticsearch.fullnameOverride }}
 {{- end -}}
 {{- end -}}
 
 {{- define "elasticsearch.masterService" -}}
-{{- if empty .Values.masterService -}}
-{{- if empty .Values.fullnameOverride -}}
-{{- if empty .Values.nameOverride -}}
-{{ .Values.clusterName }}-master
+{{- if empty .Values.elasticsearch.masterServiceValue -}}
+{{- if empty .Values.elasticsearch.fullnameOverride -}}
+{{- if empty .Values.elasticsearch.nameOverride -}}
+{{ .Values.elasticsearch.clusterName }}-master
 {{- else -}}
-{{ .Values.nameOverride }}-master
+{{ .Values.elasticsearch.nameOverride }}-master
 {{- end -}}
 {{- else -}}
-{{ .Values.fullnameOverride }}
+{{ .Values.elasticsearch.fullnameOverride }}
 {{- end -}}
 {{- else -}}
-{{ .Values.masterService }}
+{{ .Values.elasticsearch.masterServiceValue }}
 {{- end -}}
 {{- end -}}
 
 {{- define "elasticsearch.endpoints" -}}
-{{- $replicas := int (toString (.Values.replicas)) }}
+{{- $replicas := int (toString (.Values.elasticsearch.replicaCount)) }}
 {{- $uname := printf "%s-elasticsearch" .Release.Name }}
   {{- range $i, $e := untilStep 0 $replicas 1 -}}
 {{ $uname }}-{{ $i }},
@@ -400,11 +400,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "elasticsearch.esMajorVersion" -}}
-{{- if .Values.esMajorVersion -}}
-{{ .Values.esMajorVersion }}
+{{- if .Values.elasticsearch.esMajorVersionValue -}}
+{{ .Values.elasticsearch.esMajorVersionValue }}
 {{- else -}}
-{{- $version := int (index (.Values.imageTag | splitList ".") 0) -}}
-  {{- if and (contains "docker.elastic.co/elasticsearch/elasticsearch" .Values.image) (not (eq $version 0)) -}}
+{{- $version := int (index (.Values.elasticsearch.imageTag | splitList ".") 0) -}}
+  {{- if and (contains "docker.elastic.co/elasticsearch/elasticsearch" .Values.elasticsearch.image) (not (eq $version 0)) -}}
 {{ $version }}
   {{- else -}}
 7
@@ -423,24 +423,13 @@ Return the appropriate apiVersion for statefulset.
 {{- end -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "elasticsearch.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-
 {{- define "openwhisk.elasticsearch_connect" -}}
 {{- if .Values.elasticsearch.external -}}
 {{ .Values.elasticsearch.connect_string }}
 {{- else -}}
 {{- $kname := printf "%s-elasticsearch" .Release.Name }}
-{{- $kport := .Values.httpPort }}
+{{- $kport := .Values.elasticsearch.httpPort }}
 {{- $kubeDomain := .Values.k8s.domain }}
-{{- range $i, $e := until (int .Values.replicas) -}}{{ if ne $i 0 }},{{ end }}{{ $kname }}-{{ . }}.{{ $kname }}.{{ $.Release.Namespace }}.svc.{{ $kubeDomain }}:{{ $kport }}{{ end }}
+{{- range $i, $e := until (int .Values.elasticsearch.replicaCount) -}}{{ if ne $i 0 }},{{ end }}{{ $kname }}-{{ . }}.{{ $kname }}.{{ $.Release.Namespace }}.svc.{{ $kubeDomain }}:{{ $kport }}{{ end }}
 {{- end -}}
 {{- end -}}

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -433,3 +433,12 @@ Return the appropriate apiVersion for statefulset.
 {{- range $i, $e := until (int .Values.elasticsearch.replicaCount) -}}{{ if ne $i 0 }},{{ end }}{{ $kname }}-{{ . }}.{{ $kname }}.{{ $.Release.Namespace }}.svc.{{ $kubeDomain }}:{{ $kport }}{{ end }}
 {{- end -}}
 {{- end -}}
+
+{{/* host name for server.0 in elasticsearch cluster */}}
+{{- define "openwhisk.elasticsearch_zero_host" -}}
+{{- if .Values.elasticsearch.external -}}
+{{ .Values.elasticsearch.host }}
+{{- else -}}
+{{ .Release.Name }}-elasticsearch-0.{{ .Release.Name }}-elasticsearch.{{ .Release.Namespace }}.svc.{{ .Values.k8s.domain }}
+{{- end -}}
+{{- end -}}

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -389,7 +389,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "elasticsearch.endpoints" -}}
 {{- $replicas := int (toString (.Values.replicas)) }}
-{{- $uname := printf "%s-%s" .Values.clusterName .Values.nodeGroup }}
+{{- $uname := printf "%s-elasticsearch" .Release.Name }}
   {{- range $i, $e := untilStep 0 $replicas 1 -}}
 {{ $uname }}-{{ $i }},
   {{- end -}}

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -341,3 +341,91 @@ imagePullSecrets:
 {{ .Files.Get .Values.nginx.certificate.key_file }}
 {{- end -}}
 {{- end -}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elasticsearch.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "elasticsearch.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "elasticsearch.uname" -}}
+{{- if empty .Values.fullnameOverride -}}
+{{- if empty .Values.nameOverride -}}
+{{ .Values.clusterName }}-{{ .Values.nodeGroup }}
+{{- else -}}
+{{ .Values.nameOverride }}-{{ .Values.nodeGroup }}
+{{- end -}}
+{{- else -}}
+{{ .Values.fullnameOverride }}
+{{- end -}}
+{{- end -}}
+
+{{- define "elasticsearch.masterService" -}}
+{{- if empty .Values.masterService -}}
+{{- if empty .Values.fullnameOverride -}}
+{{- if empty .Values.nameOverride -}}
+{{ .Values.clusterName }}-master
+{{- else -}}
+{{ .Values.nameOverride }}-master
+{{- end -}}
+{{- else -}}
+{{ .Values.fullnameOverride }}
+{{- end -}}
+{{- else -}}
+{{ .Values.masterService }}
+{{- end -}}
+{{- end -}}
+
+{{- define "elasticsearch.endpoints" -}}
+{{- $replicas := int (toString (.Values.replicas)) }}
+{{- $uname := printf "%s-%s" .Values.clusterName .Values.nodeGroup }}
+  {{- range $i, $e := untilStep 0 $replicas 1 -}}
+{{ $uname }}-{{ $i }},
+  {{- end -}}
+{{- end -}}
+
+{{- define "elasticsearch.esMajorVersion" -}}
+{{- if .Values.esMajorVersion -}}
+{{ .Values.esMajorVersion }}
+{{- else -}}
+{{- $version := int (index (.Values.imageTag | splitList ".") 0) -}}
+  {{- if and (contains "docker.elastic.co/elasticsearch/elasticsearch" .Values.image) (not (eq $version 0)) -}}
+{{ $version }}
+  {{- else -}}
+7
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for statefulset.
+*/}}
+{{- define "elasticsearch.statefulset.apiVersion" -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1beta2" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "elasticsearch.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/helm/openwhisk/templates/_readiness.tpl
+++ b/helm/openwhisk/templates/_readiness.tpl
@@ -76,6 +76,6 @@
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
-    value: {{ .Values.protocol  }}://{{ .Release.Name }}-elasticsearch-0.{{ .Release.Name }}-elasticsearch.{{ .Release.Namespace }}.svc.{{ .Values.k8s.domain }}:{{ .Values.httpPort }}/_cluster/health
+    value: {{ .Values.elasticsearch.protocol  }}://{{ .Release.Name }}-elasticsearch-0.{{ .Release.Name }}-elasticsearch.{{ .Release.Namespace }}.svc.{{ .Values.k8s.domain }}:{{ .Values.elasticsearch.httpPort }}/_cluster/health
   command: ["sh", "-c", "while true; do echo 'checking ElasticSearch readiness'; wget -T 5 --spider $READINESS_URL --header=\"Authorization: Basic {{ include "openwhisk.elasticsearch_authentication" . | b64enc }}\"; result=$?; if [ $result -eq 0 ]; then echo 'Success: ElasticSearch is ready!'; break; fi; echo '...not ready yet; sleeping 3 seconds before retry'; sleep 3; done;"]
 {{- end -}}

--- a/helm/openwhisk/templates/_readiness.tpl
+++ b/helm/openwhisk/templates/_readiness.tpl
@@ -76,6 +76,6 @@
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
-    value: {{ .Values.elasticsearch.protocol  }}://{{ .Release.Name }}-elasticsearch-0.{{ .Release.Name }}-elasticsearch.{{ .Release.Namespace }}.svc.{{ .Values.k8s.domain }}:{{ .Values.elasticsearch.httpPort }}/_cluster/health
+    value: {{ .Values.elasticsearch.protocol  }}://{{ include "openwhisk.elasticsearch_zero_host" . }}:{{ .Values.elasticsearch.httpPort }}/_cluster/health
   command: ["sh", "-c", "while true; do echo 'checking ElasticSearch readiness'; wget -T 5 --spider $READINESS_URL --header=\"Authorization: Basic {{ include "openwhisk.elasticsearch_authentication" . | b64enc }}\"; result=$?; if [ $result -eq 0 ]; then echo 'Success: ElasticSearch is ready!'; break; fi; echo '...not ready yet; sleeping 3 seconds before retry'; sleep 3; done;"]
 {{- end -}}

--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -182,6 +182,20 @@ spec:
         - name: "CONFIG_whisk_userEvents_enabled"
           value: "true"
 {{ end }}
+{{- if eq .Values.activationStoreBackend "ElasticSearch" }}
+        - name: "CONFIG_whisk_activationStore_elasticsearch_protocol"
+          value: "{{ .Values.protocol }}"
+        - name: "CONFIG_whisk_activationStore_elasticsearch_hosts"
+          value: {{ template "openwhisk.elasticsearch_connect" . }}
+        - name: "CONFIG_whisk_activationStore_elasticsearch_indexPattern"
+          value: {{ .Values.indexPattern }}
+        - name: "CONFIG_whisk_activationStore_elasticsearch_username"
+          value: "admin"
+        - name: "CONFIG_whisk_activationStore_elasticsearch_password"
+          value: "admin"
+        - name: "CONFIG_whisk_spi_ActivationStoreProvider"
+          value: "org.apache.openwhisk.core.database.elasticsearch.ElasticSearchActivationStoreProvider"
+{{- end }}
         # properties for lean messaging provider
 {{ include "openwhisk.lean.provider" . | indent 8 }}
 

--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -62,6 +62,10 @@ spec:
 {{ include "openwhisk.readiness.waitForKafka" . | indent 6 }}
 {{- end }}
 {{ include "openwhisk.readiness.waitForCouchDB" . | indent 6 }}
+{{- if eq .Values.activationStoreBackend "ElasticSearch" }}
+      # The controller must wait for elasticsearch to be ready before it starts
+{{ include "openwhisk.readiness.waitForElasticSearch" . | indent 6 }}
+{{- end }}
       # The lean controller requires invoker volumes mounts
 {{- if .Values.controller.lean }}
 {{ include "openwhisk.invoker.volumes" . }}
@@ -190,9 +194,9 @@ spec:
         - name: "CONFIG_whisk_activationStore_elasticsearch_indexPattern"
           value: {{ .Values.indexPattern }}
         - name: "CONFIG_whisk_activationStore_elasticsearch_username"
-          value: "admin"
+          value: "{{ .Values.username }}"
         - name: "CONFIG_whisk_activationStore_elasticsearch_password"
-          value: "admin"
+          value: "{{ .Values.password }}"
         - name: "CONFIG_whisk_spi_ActivationStoreProvider"
           value: "org.apache.openwhisk.core.database.elasticsearch.ElasticSearchActivationStoreProvider"
 {{- end }}

--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -188,15 +188,15 @@ spec:
 {{ end }}
 {{- if eq .Values.activationStoreBackend "ElasticSearch" }}
         - name: "CONFIG_whisk_activationStore_elasticsearch_protocol"
-          value: "{{ .Values.protocol }}"
+          value: "{{ .Values.elasticsearch.protocol }}"
         - name: "CONFIG_whisk_activationStore_elasticsearch_hosts"
           value: {{ template "openwhisk.elasticsearch_connect" . }}
         - name: "CONFIG_whisk_activationStore_elasticsearch_indexPattern"
-          value: {{ .Values.indexPattern }}
+          value: {{ .Values.elasticsearch.indexPattern }}
         - name: "CONFIG_whisk_activationStore_elasticsearch_username"
-          value: "{{ .Values.username }}"
+          value: "{{ .Values.elasticsearch.username }}"
         - name: "CONFIG_whisk_activationStore_elasticsearch_password"
-          value: "{{ .Values.password }}"
+          value: "{{ .Values.elasticsearch.password }}"
         - name: "CONFIG_whisk_spi_ActivationStoreProvider"
           value: "org.apache.openwhisk.core.database.elasticsearch.ElasticSearchActivationStoreProvider"
 {{- end }}

--- a/helm/openwhisk/templates/elasticsearch-cm.yaml
+++ b/helm/openwhisk/templates/elasticsearch-cm.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.esConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "elasticsearch.uname" . }}-config
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    app: "{{ template "elasticsearch.uname" . }}"
+data:
+{{- range $path, $config := .Values.esConfig }}
+  {{ $path }}: |
+{{ $config | indent 4 -}}
+{{- end -}}
+{{- end -}}

--- a/helm/openwhisk/templates/elasticsearch-cm.yaml
+++ b/helm/openwhisk/templates/elasticsearch-cm.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 {{- if and (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") .Values.elasticsearch.esConfig }}
 apiVersion: v1
 kind: ConfigMap

--- a/helm/openwhisk/templates/elasticsearch-cm.yaml
+++ b/helm/openwhisk/templates/elasticsearch-cm.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.elasticsearch.esConfig }}
+{{- if and (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") .Values.elasticsearch.esConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/openwhisk/templates/elasticsearch-cm.yaml
+++ b/helm/openwhisk/templates/elasticsearch-cm.yaml
@@ -2,12 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "elasticsearch.uname" . }}-config
+  name: {{ .Release.Name }}-elasticsearch-cm
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
+{{ include "openwhisk.label_boilerplate" .| indent 4 }}
 data:
 {{- range $path, $config := .Values.esConfig }}
   {{ $path }}: |

--- a/helm/openwhisk/templates/elasticsearch-cm.yaml
+++ b/helm/openwhisk/templates/elasticsearch-cm.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.esConfig }}
+{{- if .Values.elasticsearch.esConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ include "openwhisk.label_boilerplate" .| indent 4 }}
 data:
-{{- range $path, $config := .Values.esConfig }}
+{{- range $path, $config := .Values.elasticsearch.esConfig }}
   {{ $path }}: |
 {{ $config | indent 4 -}}
 {{- end -}}

--- a/helm/openwhisk/templates/elasticsearch-pdb.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pdb.yaml
@@ -1,0 +1,12 @@
+---
+{{- if .Values.maxUnavailable }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "{{ template "elasticsearch.uname" . }}-pdb"
+spec:
+  maxUnavailable: {{ .Values.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: "{{ template "elasticsearch.uname" . }}"
+{{- end }}

--- a/helm/openwhisk/templates/elasticsearch-pdb.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pdb.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ---
 {{- if and .Values.pdb.enable (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 apiVersion: policy/v1beta1

--- a/helm/openwhisk/templates/elasticsearch-pdb.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pdb.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if .Values.maxUnavailable }}
+{{- if and .Values.pdb.enable (.Values.pdb.elasticsearch.maxUnavailable) (not .Values.elasticsearch.external) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -7,8 +7,8 @@ metadata:
   labels:
 {{ include "openwhisk.label_boilerplate" .| indent 4 }}
 spec:
-  maxUnavailable: {{ .Values.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.elasticsearch.maxUnavailable }}
   selector:
     matchLabels:
-      app: "{{ template "elasticsearch.uname" . }}"
+      name: {{ .Release.Name }}-elasticsearch
 {{- end }}

--- a/helm/openwhisk/templates/elasticsearch-pdb.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pdb.yaml
@@ -3,7 +3,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: "{{ template "elasticsearch.uname" . }}-pdb"
+  name: {{ .Release.Name }}-elasticsearch-pdb
+  labels:
+{{ include "openwhisk.label_boilerplate" .| indent 4 }}
 spec:
   maxUnavailable: {{ .Values.maxUnavailable }}
   selector:

--- a/helm/openwhisk/templates/elasticsearch-pdb.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pdb.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if and .Values.pdb.enable (.Values.pdb.elasticsearch.maxUnavailable) (not .Values.elasticsearch.external) }}
+{{- if and .Values.pdb.enable (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "openwhisk.label_boilerplate" .| indent 4 }}
 spec:
-  maxUnavailable: {{ .Values.pdb.elasticsearch.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.elasticsearch.maxUnavailable | default 1 }}
   selector:
     matchLabels:
       name: {{ .Release.Name }}-elasticsearch

--- a/helm/openwhisk/templates/elasticsearch-pod.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pod.yaml
@@ -1,0 +1,419 @@
+---
+apiVersion: {{ template "elasticsearch.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ template "elasticsearch.uname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    app: "{{ template "elasticsearch.uname" . }}"
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  annotations:
+    esMajorVersion: "{{ include "elasticsearch.esMajorVersion" . }}"
+spec:
+  serviceName: {{ template "elasticsearch.uname" . }}-headless
+  selector:
+    matchLabels:
+      app: "{{ template "elasticsearch.uname" . }}"
+  replicas: {{ .Values.replicas }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ template "elasticsearch.uname" . }}
+    {{- with .Values.persistence.annotations  }}
+      annotations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    spec:
+{{ toYaml .Values.volumeClaimTemplate | indent 6 }}
+  {{- end }}
+  template:
+    metadata:
+      name: "{{ template "elasticsearch.uname" . }}"
+      labels:
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}"
+        app: "{{ template "elasticsearch.uname" . }}"
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{/* This forces a restart if the configmap has changed */}}
+        {{- if .Values.esConfig }}
+        configchecksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
+        {{- end }}
+    spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+        {{- if .Values.fsGroup }}
+        fsGroup: {{ .Values.fsGroup }} # Deprecated value, please use .Values.podSecurityContext.fsGroup
+        {{- end }}
+      {{- if .Values.rbac.create }}
+      serviceAccountName: "{{ template "elasticsearch.uname" . }}"
+      {{- else if not (eq .Values.rbac.serviceAccountName "") }}
+      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 6 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if or (eq .Values.antiAffinity "hard") (eq .Values.antiAffinity "soft") .Values.nodeAffinity }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      affinity:
+      {{- end }}
+      {{- if eq .Values.antiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - "{{ template "elasticsearch.uname" .}}"
+            topologyKey: {{ .Values.antiAffinityTopologyKey }}
+      {{- else if eq .Values.antiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: {{ .Values.antiAffinityTopologyKey }}
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - "{{ template "elasticsearch.uname" . }}"
+      {{- end }}
+      {{- with .Values.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriod }}
+      volumes:
+        {{- range .Values.secretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            {{- if .defaultMode }}
+            defaultMode: {{ .defaultMode }}
+            {{- end }}
+        {{- end }}
+        {{- if .Values.esConfig }}
+        - name: esconfig
+          configMap:
+            name: {{ template "elasticsearch.uname" . }}-config
+        {{- end }}
+{{- if .Values.keystore }}
+        - name: keystore
+          emptyDir: {}
+        {{- range .Values.keystore }}
+        - name: keystore-{{ .secretName }}
+          secret: {{ toYaml . | nindent 12 }}
+        {{- end }}
+{{ end }}
+      {{- if .Values.extraVolumes }}
+      # Currently some extra blocks accept strings
+      # to continue with backwards compatibility this is being kept
+      # whilst also allowing for yaml to be specified too.
+      {{- if eq "string" (printf "%T" .Values.extraVolumes) }}
+{{ tpl .Values.extraVolumes . | indent 8 }}
+      {{- else }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if semverCompare ">1.13" .Capabilities.KubeVersion.GitVersion }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
+      {{- end }}
+      initContainers:
+      {{- if .Values.sysctlInitContainer.enabled }}
+      - name: configure-sysctl
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        command: ["sysctl", "-w", "vm.max_map_count={{ .Values.sysctlVmMaxMapCount}}"]
+        resources:
+{{ toYaml .Values.initResources | indent 10 }}
+      {{- end }}
+{{ if .Values.keystore }}
+      - name: keystore
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        command:
+        - sh
+        - -c
+        - |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          elasticsearch-keystore create
+
+          for i in /tmp/keystoreSecrets/*/*; do
+            key=$(basename $i)
+            echo "Adding file $i to keystore key $key"
+            elasticsearch-keystore add-file "$key" "$i"
+          done
+
+          # Add the bootstrap password since otherwise the Elasticsearch entrypoint tries to do this on startup
+          if [ ! -z ${ELASTIC_PASSWORD+x} ]; then
+            echo 'Adding env $ELASTIC_PASSWORD to keystore as key bootstrap.password'
+            echo "$ELASTIC_PASSWORD" | elasticsearch-keystore add -x bootstrap.password
+          fi
+
+          cp -a /usr/share/elasticsearch/config/elasticsearch.keystore /tmp/keystore/
+        env: {{ toYaml .Values.extraEnvs | nindent 10 }}
+        envFrom: {{ toYaml .Values.envFrom | nindent 10 }}
+        resources: {{ toYaml .Values.initResources | nindent 10 }}
+        volumeMounts:
+          - name: keystore
+            mountPath: /tmp/keystore
+          {{- range .Values.keystore }}
+          - name: keystore-{{ .secretName }}
+            mountPath: /tmp/keystoreSecrets/{{ .secretName }}
+          {{- end }}
+{{ end }}
+      {{- if .Values.extraInitContainers }}
+      # Currently some extra blocks accept strings
+      # to continue with backwards compatibility this is being kept
+      # whilst also allowing for yaml to be specified too.
+      {{- if eq "string" (printf "%T" .Values.extraInitContainers) }}
+{{ tpl .Values.extraInitContainers . | indent 6 }}
+      {{- else }}
+{{ toYaml .Values.extraInitContainers | indent 6 }}
+      {{- end }}
+      {{- end }}
+      containers:
+      - name: "{{ template "elasticsearch.name" . }}"
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        readinessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - |
+                #!/usr/bin/env bash -e
+                # If the node is starting up wait for the cluster to be ready (request params: "{{ .Values.clusterHealthCheckParams }}" )
+                # Once it has started only check that the node itself is responding
+                START_FILE=/tmp/.es_start_file
+
+                http () {
+                  local path="${1}"
+                  local args="${2}"
+                  set -- -XGET -s
+
+                  if [ "$args" != "" ]; then
+                    set -- "$@" $args
+                  fi
+
+                  if [ -n "${ELASTIC_USERNAME}" ] && [ -n "${ELASTIC_PASSWORD}" ]; then
+                    set -- "$@" -u "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
+                  fi
+
+                  curl --output /dev/null -k "$@" "{{ .Values.protocol }}://127.0.0.1:{{ .Values.httpPort }}${path}"
+                }
+
+                if [ -f "${START_FILE}" ]; then
+                  echo 'Elasticsearch is already running, lets check the node is healthy'
+                  HTTP_CODE=$(http "/" "-w %{http_code}")
+                  RC=$?
+                  if [[ ${RC} -ne 0 ]]; then
+                    echo "curl --output /dev/null -k -XGET -s -w '%{http_code}' \${BASIC_AUTH} {{ .Values.protocol }}://127.0.0.1:{{ .Values.httpPort }}/ failed with RC ${RC}"
+                    exit ${RC}
+                  fi
+                  # ready if HTTP code 200, 503 is tolerable if ES version is 6.x
+                  if [[ ${HTTP_CODE} == "200" ]]; then
+                    exit 0
+                  elif [[ ${HTTP_CODE} == "503" && "{{ include "elasticsearch.esMajorVersion" . }}" == "6" ]]; then
+                    exit 0
+                  else
+                    echo "curl --output /dev/null -k -XGET -s -w '%{http_code}' \${BASIC_AUTH} {{ .Values.protocol }}://127.0.0.1:{{ .Values.httpPort }}/ failed with HTTP code ${HTTP_CODE}"
+                    exit 1
+                  fi
+
+                else
+                  echo 'Waiting for elasticsearch cluster to become ready (request params: "{{ .Values.clusterHealthCheckParams }}" )'
+                  if http "/_cluster/health?{{ .Values.clusterHealthCheckParams }}" "--fail" ; then
+                    touch ${START_FILE}
+                    exit 0
+                  else
+                    echo 'Cluster is not yet ready (request params: "{{ .Values.clusterHealthCheckParams }}" )'
+                    exit 1
+                  fi
+                fi
+{{ toYaml .Values.readinessProbe | indent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.httpPort }}
+        - name: transport
+          containerPort: {{ .Values.transportPort }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        env:
+          - name: node.name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          {{- if eq .Values.roles.master "true" }}
+          {{- if ge (int (include "elasticsearch.esMajorVersion" .)) 7 }}
+          - name: cluster.initial_master_nodes
+            value: "{{ template "elasticsearch.endpoints" . }}"
+          {{- else }}
+          - name: discovery.zen.minimum_master_nodes
+            value: "{{ .Values.minimumMasterNodes }}"
+          {{- end }}
+          {{- end }}
+          {{- if lt (int (include "elasticsearch.esMajorVersion" .)) 7 }}
+          - name: discovery.zen.ping.unicast.hosts
+            value: "{{ template "elasticsearch.masterService" . }}-headless"
+          {{- else }}
+          - name: discovery.seed_hosts
+            value: "{{ template "elasticsearch.masterService" . }}-headless"
+          {{- end }}
+          - name: cluster.name
+            value: "{{ .Values.clusterName }}"
+          - name: network.host
+            value: "{{ .Values.networkHost }}"
+          - name: ES_JAVA_OPTS
+            value: "{{ .Values.esJavaOpts }}"
+          {{- range $role, $enabled := .Values.roles }}
+          - name: node.{{ $role }}
+            value: "{{ $enabled }}"
+          {{- end }}
+{{- if .Values.extraEnvs }}
+{{ toYaml .Values.extraEnvs | indent 10 }}
+{{- end }}
+{{- if .Values.envFrom }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
+{{- end }}
+        volumeMounts:
+          {{- if .Values.persistence.enabled }}
+          - name: "{{ template "elasticsearch.uname" . }}"
+            mountPath: /usr/share/elasticsearch/data
+          {{- end }}
+{{ if .Values.keystore }}
+          - name: keystore
+            mountPath: /usr/share/elasticsearch/config/elasticsearch.keystore
+            subPath: elasticsearch.keystore
+{{ end }}
+          {{- range .Values.secretMounts }}
+          - name: {{ .name }}
+            mountPath: {{ .path }}
+            {{- if .subPath }}
+            subPath: {{ .subPath }}
+            {{- end }}
+          {{- end }}
+          {{- range $path, $config := .Values.esConfig }}
+          - name: esconfig
+            mountPath: /usr/share/elasticsearch/config/{{ $path }}
+            subPath: {{ $path }}
+          {{- end -}}
+        {{- if .Values.extraVolumeMounts }}
+        # Currently some extra blocks accept strings
+        # to continue with backwards compatibility this is being kept
+        # whilst also allowing for yaml to be specified too.
+        {{- if eq "string" (printf "%T" .Values.extraVolumeMounts) }}
+{{ tpl .Values.extraVolumeMounts . | indent 10 }}
+        {{- else }}
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+        {{- end }}
+        {{- end }}
+      {{- if .Values.masterTerminationFix }}
+      {{- if eq .Values.roles.master "true" }}
+      # This sidecar will prevent slow master re-election
+      # https://github.com/elastic/helm-charts/issues/63
+      - name: elasticsearch-master-graceful-termination-handler
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        command:
+        - "sh"
+        - -c
+        - |
+          #!/usr/bin/env bash
+          set -eo pipefail
+
+          http () {
+              local path="${1}"
+              if [ -n "${ELASTIC_USERNAME}" ] && [ -n "${ELASTIC_PASSWORD}" ]; then
+                BASIC_AUTH="-u ${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
+              else
+                BASIC_AUTH=''
+              fi
+              curl -XGET -s -k --fail ${BASIC_AUTH} {{ .Values.protocol }}://{{ template "elasticsearch.masterService" . }}:{{ .Values.httpPort }}${path}
+          }
+
+          cleanup () {
+            while true ; do
+              local master="$(http "/_cat/master?h=node" || echo "")"
+              if [[ $master == "{{ template "elasticsearch.masterService" . }}"* && $master != "${NODE_NAME}" ]]; then
+                echo "This node is not master."
+                break
+              fi
+              echo "This node is still master, waiting gracefully for it to step down"
+              sleep 1
+            done
+
+            exit 0
+          }
+
+          trap cleanup SIGTERM
+
+          sleep infinity &
+          wait $!
+        resources:
+{{ toYaml .Values.sidecarResources | indent 10 }}
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        {{- if .Values.extraEnvs }}
+{{ toYaml .Values.extraEnvs | indent 10 }}
+        {{- end }}
+        {{- if .Values.envFrom }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
+{{- if .Values.lifecycle }}
+        lifecycle:
+{{ toYaml .Values.lifecycle | indent 10 }}
+{{- end }}
+      {{- if .Values.extraContainers }}
+      # Currently some extra blocks accept strings
+      # to continue with backwards compatibility this is being kept
+      # whilst also allowing for yaml to be specified too.
+      {{- if eq "string" (printf "%T" .Values.extraContainers) }}
+{{ tpl .Values.extraContainers . | indent 6 }}
+      {{- else }}
+{{ toYaml .Values.extraContainers | indent 6 }}
+      {{- end }}
+      {{- end }}

--- a/helm/openwhisk/templates/elasticsearch-pod.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pod.yaml
@@ -2,22 +2,17 @@
 apiVersion: {{ template "elasticsearch.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
-  name: {{ template "elasticsearch.uname" . }}
+  name: {{ .Release.Name }}-elasticsearch
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
-    {{- range $key, $value := .Values.labels }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+    name: {{ .Release.Name }}-elasticsearch
+{{ include "openwhisk.label_boilerplate" . | indent 4 }}
   annotations:
     esMajorVersion: "{{ include "elasticsearch.esMajorVersion" . }}"
 spec:
-  serviceName: {{ template "elasticsearch.uname" . }}-headless
+  serviceName: {{ .Release.Name }}-elasticsearch-headless
   selector:
     matchLabels:
-      app: "{{ template "elasticsearch.uname" . }}"
+      name: {{ .Release.Name }}-elasticsearch
   replicas: {{ .Values.replicas }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
@@ -35,15 +30,9 @@ spec:
   {{- end }}
   template:
     metadata:
-      name: "{{ template "elasticsearch.uname" . }}"
       labels:
-        heritage: {{ .Release.Service | quote }}
-        release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}"
-        app: "{{ template "elasticsearch.uname" . }}"
-        {{- range $key, $value := .Values.labels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
+        name: {{ .Release.Name }}-elasticsearch
+{{ include "openwhisk.label_boilerplate" . | indent 8 }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
@@ -120,7 +109,7 @@ spec:
         {{- if .Values.esConfig }}
         - name: esconfig
           configMap:
-            name: {{ template "elasticsearch.uname" . }}-config
+            name: {{ .Release.Name }}-elasticsearch-cm
         {{- end }}
 {{- if .Values.keystore }}
         - name: keystore

--- a/helm/openwhisk/templates/elasticsearch-pod.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pod.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     esMajorVersion: "{{ include "elasticsearch.esMajorVersion" . }}"
 spec:
-  serviceName: {{ .Release.Name }}-elasticsearch-headless
+  serviceName: {{ .Release.Name }}-elasticsearch
   selector:
     matchLabels:
       name: {{ .Release.Name }}-elasticsearch
@@ -280,10 +280,10 @@ spec:
           {{- end }}
           {{- if lt (int (include "elasticsearch.esMajorVersion" .)) 7 }}
           - name: discovery.zen.ping.unicast.hosts
-            value: "{{ template "elasticsearch.masterService" . }}-headless"
+            value: "{{ .Release.Name }}-elasticsearch"
           {{- else }}
           - name: discovery.seed_hosts
-            value: "{{ template "elasticsearch.masterService" . }}-headless"
+            value: "{{ .Release.Name }}-elasticsearch"
           {{- end }}
           - name: cluster.name
             value: "{{ .Values.clusterName }}"

--- a/helm/openwhisk/templates/elasticsearch-pod.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pod.yaml
@@ -56,47 +56,18 @@ spec:
       {{- else if not (eq .Values.elasticsearch.rbac.serviceAccountName "") }}
       serviceAccountName: {{ .Values.elasticsearch.rbac.serviceAccountName | quote }}
       {{- end }}
-      {{- with .Values.elasticsearch.tolerations }}
-      tolerations:
-{{ toYaml . | indent 6 }}
-      {{- end }}
-      {{- with .Values.elasticsearch.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-      {{- end }}
-      {{- if or (eq .Values.elasticsearch.antiAffinity "hard") (eq .Values.elasticsearch.antiAffinity "soft") .Values.elasticsearch.nodeAffinity }}
-      {{- if .Values.elasticsearch.priorityClassName }}
-      priorityClassName: {{ .Values.elasticsearch.priorityClassName }}
-      {{- end }}
+
+      {{- if .Values.affinity.enabled }}
       affinity:
+{{ include "openwhisk.affinity.core" . | indent 8 }}
+{{ include "openwhisk.affinity.selfAntiAffinity" ( printf "%s-elasticsearch" .Release.Name ) | indent 8 }}
       {{- end }}
-      {{- if eq .Values.elasticsearch.antiAffinity "hard" }}
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - "{{ template "elasticsearch.uname" .}}"
-            topologyKey: {{ .Values.elasticsearch.antiAffinityTopologyKey }}
-      {{- else if eq .Values.elasticsearch.antiAffinity "soft" }}
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: {{ .Values.elasticsearch.antiAffinityTopologyKey }}
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - "{{ template "elasticsearch.uname" . }}"
+
+      {{- if .Values.toleration.enabled }}
+      tolerations:
+{{ include "openwhisk.toleration.core" . | indent 8 }}
       {{- end }}
-      {{- with .Values.elasticsearch.nodeAffinity }}
-        nodeAffinity:
-{{ toYaml . | indent 10 }}
-      {{- end }}
+
       terminationGracePeriodSeconds: {{ .Values.elasticsearch.terminationGracePeriod }}
       volumes:
         {{- range .Values.elasticsearch.secretMounts }}

--- a/helm/openwhisk/templates/elasticsearch-pod.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pod.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 {{- if and (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 ---
 apiVersion: {{ template "elasticsearch.statefulset.apiVersion" . }}

--- a/helm/openwhisk/templates/elasticsearch-pod.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pod.yaml
@@ -1,3 +1,4 @@
+{{- if and (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 ---
 apiVersion: {{ template "elasticsearch.statefulset.apiVersion" . }}
 kind: StatefulSet
@@ -406,3 +407,4 @@ spec:
 {{ toYaml .Values.elasticsearch.extraContainers | indent 6 }}
       {{- end }}
       {{- end }}
+{{- end }}

--- a/helm/openwhisk/templates/elasticsearch-pod.yaml
+++ b/helm/openwhisk/templates/elasticsearch-pod.yaml
@@ -13,20 +13,20 @@ spec:
   selector:
     matchLabels:
       name: {{ .Release.Name }}-elasticsearch
-  replicas: {{ .Values.replicas }}
-  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  replicas: {{ .Values.elasticsearch.replicaCount }}
+  podManagementPolicy: {{ .Values.elasticsearch.podManagementPolicy }}
   updateStrategy:
-    type: {{ .Values.updateStrategy }}
-  {{- if .Values.persistence.enabled }}
+    type: {{ .Values.elasticsearch.updateStrategy }}
+  {{- if .Values.k8s.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: {{ template "elasticsearch.uname" . }}
-    {{- with .Values.persistence.annotations  }}
+    {{- with .Values.elasticsearch.persistence.annotations  }}
       annotations:
 {{ toYaml . | indent 8 }}
     {{- end }}
     spec:
-{{ toYaml .Values.volumeClaimTemplate | indent 6 }}
+{{ toYaml .Values.elasticsearch.volumeClaimTemplate | indent 6 }}
   {{- end }}
   template:
     metadata:
@@ -34,42 +34,42 @@ spec:
         name: {{ .Release.Name }}-elasticsearch
 {{ include "openwhisk.label_boilerplate" . | indent 8 }}
       annotations:
-        {{- range $key, $value := .Values.podAnnotations }}
+        {{- range $key, $value := .Values.elasticsearch.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{/* This forces a restart if the configmap has changed */}}
-        {{- if .Values.esConfig }}
+        {{- if .Values.elasticsearch.esConfig }}
         configchecksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
         {{- end }}
     spec:
-      {{- if .Values.schedulerName }}
-      schedulerName: "{{ .Values.schedulerName }}"
+      {{- if .Values.elasticsearch.schedulerName }}
+      schedulerName: "{{ .Values.elasticsearch.schedulerName }}"
       {{- end }}
       securityContext:
-{{ toYaml .Values.podSecurityContext | indent 8 }}
-        {{- if .Values.fsGroup }}
-        fsGroup: {{ .Values.fsGroup }} # Deprecated value, please use .Values.podSecurityContext.fsGroup
+{{ toYaml .Values.elasticsearch.podSecurityContext | indent 8 }}
+        {{- if .Values.elasticsearch.fsGroup }}
+        fsGroup: {{ .Values.elasticsearch.fsGroup }} # Deprecated value, please use .Values.podSecurityContext.fsGroup
         {{- end }}
-      {{- if .Values.rbac.create }}
+      {{- if .Values.elasticsearch.rbac.create }}
       serviceAccountName: "{{ template "elasticsearch.uname" . }}"
-      {{- else if not (eq .Values.rbac.serviceAccountName "") }}
-      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
+      {{- else if not (eq .Values.elasticsearch.rbac.serviceAccountName "") }}
+      serviceAccountName: {{ .Values.elasticsearch.rbac.serviceAccountName | quote }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.elasticsearch.tolerations }}
       tolerations:
 {{ toYaml . | indent 6 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.elasticsearch.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}
-      {{- if or (eq .Values.antiAffinity "hard") (eq .Values.antiAffinity "soft") .Values.nodeAffinity }}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+      {{- if or (eq .Values.elasticsearch.antiAffinity "hard") (eq .Values.elasticsearch.antiAffinity "soft") .Values.elasticsearch.nodeAffinity }}
+      {{- if .Values.elasticsearch.priorityClassName }}
+      priorityClassName: {{ .Values.elasticsearch.priorityClassName }}
       {{- end }}
       affinity:
       {{- end }}
-      {{- if eq .Values.antiAffinity "hard" }}
+      {{- if eq .Values.elasticsearch.antiAffinity "hard" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -78,13 +78,13 @@ spec:
                 operator: In
                 values:
                 - "{{ template "elasticsearch.uname" .}}"
-            topologyKey: {{ .Values.antiAffinityTopologyKey }}
-      {{- else if eq .Values.antiAffinity "soft" }}
+            topologyKey: {{ .Values.elasticsearch.antiAffinityTopologyKey }}
+      {{- else if eq .Values.elasticsearch.antiAffinity "soft" }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
             podAffinityTerm:
-              topologyKey: {{ .Values.antiAffinityTopologyKey }}
+              topologyKey: {{ .Values.elasticsearch.antiAffinityTopologyKey }}
               labelSelector:
                 matchExpressions:
                 - key: app
@@ -92,13 +92,13 @@ spec:
                   values:
                   - "{{ template "elasticsearch.uname" . }}"
       {{- end }}
-      {{- with .Values.nodeAffinity }}
+      {{- with .Values.elasticsearch.nodeAffinity }}
         nodeAffinity:
 {{ toYaml . | indent 10 }}
       {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriod }}
+      terminationGracePeriodSeconds: {{ .Values.elasticsearch.terminationGracePeriod }}
       volumes:
-        {{- range .Values.secretMounts }}
+        {{- range .Values.elasticsearch.secretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
@@ -106,52 +106,52 @@ spec:
             defaultMode: {{ .defaultMode }}
             {{- end }}
         {{- end }}
-        {{- if .Values.esConfig }}
+        {{- if .Values.elasticsearch.esConfig }}
         - name: esconfig
           configMap:
             name: {{ .Release.Name }}-elasticsearch-cm
         {{- end }}
-{{- if .Values.keystore }}
+{{- if .Values.elasticsearch.keystore }}
         - name: keystore
           emptyDir: {}
-        {{- range .Values.keystore }}
+        {{- range .Values.elasticsearch.keystore }}
         - name: keystore-{{ .secretName }}
           secret: {{ toYaml . | nindent 12 }}
         {{- end }}
 {{ end }}
-      {{- if .Values.extraVolumes }}
+      {{- if .Values.elasticsearch.extraVolumes }}
       # Currently some extra blocks accept strings
       # to continue with backwards compatibility this is being kept
       # whilst also allowing for yaml to be specified too.
-      {{- if eq "string" (printf "%T" .Values.extraVolumes) }}
-{{ tpl .Values.extraVolumes . | indent 8 }}
+      {{- if eq "string" (printf "%T" .Values.elasticsearch.extraVolumes) }}
+{{ tpl .Values.elasticsearch.extraVolumes . | indent 8 }}
       {{- else }}
-{{ toYaml .Values.extraVolumes | indent 8 }}
+{{ toYaml .Values.elasticsearch.extraVolumes | indent 8 }}
       {{- end }}
       {{- end }}
-      {{- if .Values.imagePullSecrets }}
+      {{- if .Values.elasticsearch.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{ toYaml .Values.elasticsearch.imagePullSecrets | indent 8 }}
       {{- end }}
       {{- if semverCompare ">1.13" .Capabilities.KubeVersion.GitVersion }}
-      enableServiceLinks: {{ .Values.enableServiceLinks }}
+      enableServiceLinks: {{ .Values.elasticsearch.enableServiceLinks }}
       {{- end }}
       initContainers:
-      {{- if .Values.sysctlInitContainer.enabled }}
+      {{- if .Values.elasticsearch.sysctlInitContainer.enabled }}
       - name: configure-sysctl
         securityContext:
           runAsUser: 0
           privileged: true
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
-        command: ["sysctl", "-w", "vm.max_map_count={{ .Values.sysctlVmMaxMapCount}}"]
+        image: "{{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.imageTag }}"
+        imagePullPolicy: "{{ .Values.elasticsearch.imagePullPolicy }}"
+        command: ["sysctl", "-w", "vm.max_map_count={{ .Values.elasticsearch.sysctlVmMaxMapCount}}"]
         resources:
-{{ toYaml .Values.initResources | indent 10 }}
+{{ toYaml .Values.elasticsearch.initResources | indent 10 }}
       {{- end }}
-{{ if .Values.keystore }}
+{{ if .Values.elasticsearch.keystore }}
       - name: keystore
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        image: "{{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.imageTag }}"
+        imagePullPolicy: "{{ .Values.elasticsearch.imagePullPolicy }}"
         command:
         - sh
         - -c
@@ -174,33 +174,33 @@ spec:
           fi
 
           cp -a /usr/share/elasticsearch/config/elasticsearch.keystore /tmp/keystore/
-        env: {{ toYaml .Values.extraEnvs | nindent 10 }}
-        envFrom: {{ toYaml .Values.envFrom | nindent 10 }}
-        resources: {{ toYaml .Values.initResources | nindent 10 }}
+        env: {{ toYaml .Values.elasticsearch.extraEnvs | nindent 10 }}
+        envFrom: {{ toYaml .Values.elasticsearch.envFrom | nindent 10 }}
+        resources: {{ toYaml .Values.elasticsearch.initResources | nindent 10 }}
         volumeMounts:
           - name: keystore
             mountPath: /tmp/keystore
-          {{- range .Values.keystore }}
+          {{- range .Values.elasticsearch.keystore }}
           - name: keystore-{{ .secretName }}
             mountPath: /tmp/keystoreSecrets/{{ .secretName }}
           {{- end }}
 {{ end }}
-      {{- if .Values.extraInitContainers }}
+      {{- if .Values.elasticsearch.extraInitContainers }}
       # Currently some extra blocks accept strings
       # to continue with backwards compatibility this is being kept
       # whilst also allowing for yaml to be specified too.
-      {{- if eq "string" (printf "%T" .Values.extraInitContainers) }}
-{{ tpl .Values.extraInitContainers . | indent 6 }}
+      {{- if eq "string" (printf "%T" .Values.elasticsearch.extraInitContainers) }}
+{{ tpl .Values.elasticsearch.extraInitContainers . | indent 6 }}
       {{- else }}
-{{ toYaml .Values.extraInitContainers | indent 6 }}
+{{ toYaml .Values.elasticsearch.extraInitContainers | indent 6 }}
       {{- end }}
       {{- end }}
       containers:
       - name: "{{ template "elasticsearch.name" . }}"
         securityContext:
-{{ toYaml .Values.securityContext | indent 10 }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+{{ toYaml .Values.elasticsearch.securityContext | indent 10 }}
+        image: "{{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.imageTag }}"
+        imagePullPolicy: "{{ .Values.elasticsearch.imagePullPolicy }}"
         readinessProbe:
           exec:
             command:
@@ -208,7 +208,7 @@ spec:
               - -c
               - |
                 #!/usr/bin/env bash -e
-                # If the node is starting up wait for the cluster to be ready (request params: "{{ .Values.clusterHealthCheckParams }}" )
+                # If the node is starting up wait for the cluster to be ready (request params: "{{ .Values.elasticsearch.clusterHealthCheckParams }}" )
                 # Once it has started only check that the node itself is responding
                 START_FILE=/tmp/.es_start_file
 
@@ -225,7 +225,7 @@ spec:
                     set -- "$@" -u "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
                   fi
 
-                  curl --output /dev/null -k "$@" "{{ .Values.protocol }}://127.0.0.1:{{ .Values.httpPort }}${path}"
+                  curl --output /dev/null -k "$@" "{{ .Values.elasticsearch.protocol }}://127.0.0.1:{{ .Values.elasticsearch.httpPort }}${path}"
                 }
 
                 if [ -f "${START_FILE}" ]; then
@@ -233,7 +233,7 @@ spec:
                   HTTP_CODE=$(http "/" "-w %{http_code}")
                   RC=$?
                   if [[ ${RC} -ne 0 ]]; then
-                    echo "curl --output /dev/null -k -XGET -s -w '%{http_code}' \${BASIC_AUTH} {{ .Values.protocol }}://127.0.0.1:{{ .Values.httpPort }}/ failed with RC ${RC}"
+                    echo "curl --output /dev/null -k -XGET -s -w '%{http_code}' \${BASIC_AUTH} {{ .Values.elasticsearch.protocol }}://127.0.0.1:{{ .Values.elasticsearch.httpPort }}/ failed with RC ${RC}"
                     exit ${RC}
                   fi
                   # ready if HTTP code 200, 503 is tolerable if ES version is 6.x
@@ -242,40 +242,40 @@ spec:
                   elif [[ ${HTTP_CODE} == "503" && "{{ include "elasticsearch.esMajorVersion" . }}" == "6" ]]; then
                     exit 0
                   else
-                    echo "curl --output /dev/null -k -XGET -s -w '%{http_code}' \${BASIC_AUTH} {{ .Values.protocol }}://127.0.0.1:{{ .Values.httpPort }}/ failed with HTTP code ${HTTP_CODE}"
+                    echo "curl --output /dev/null -k -XGET -s -w '%{http_code}' \${BASIC_AUTH} {{ .Values.elasticsearch.protocol }}://127.0.0.1:{{ .Values.elasticsearch.httpPort }}/ failed with HTTP code ${HTTP_CODE}"
                     exit 1
                   fi
 
                 else
-                  echo 'Waiting for elasticsearch cluster to become ready (request params: "{{ .Values.clusterHealthCheckParams }}" )'
-                  if http "/_cluster/health?{{ .Values.clusterHealthCheckParams }}" "--fail" ; then
+                  echo 'Waiting for elasticsearch cluster to become ready (request params: "{{ .Values.elasticsearch.clusterHealthCheckParams }}" )'
+                  if http "/_cluster/health?{{ .Values.elasticsearch.clusterHealthCheckParams }}" "--fail" ; then
                     touch ${START_FILE}
                     exit 0
                   else
-                    echo 'Cluster is not yet ready (request params: "{{ .Values.clusterHealthCheckParams }}" )'
+                    echo 'Cluster is not yet ready (request params: "{{ .Values.elasticsearch.clusterHealthCheckParams }}" )'
                     exit 1
                   fi
                 fi
-{{ toYaml .Values.readinessProbe | indent 10 }}
+{{ toYaml .Values.elasticsearch.readinessProbe | indent 10 }}
         ports:
         - name: http
-          containerPort: {{ .Values.httpPort }}
+          containerPort: {{ .Values.elasticsearch.httpPort }}
         - name: transport
-          containerPort: {{ .Values.transportPort }}
+          containerPort: {{ .Values.elasticsearch.transportPort }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+{{ toYaml .Values.elasticsearch.resources | indent 10 }}
         env:
           - name: node.name
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          {{- if eq .Values.roles.master "true" }}
+          {{- if eq .Values.elasticsearch.roles.master "true" }}
           {{- if ge (int (include "elasticsearch.esMajorVersion" .)) 7 }}
           - name: cluster.initial_master_nodes
             value: "{{ template "elasticsearch.endpoints" . }}"
           {{- else }}
           - name: discovery.zen.minimum_master_nodes
-            value: "{{ .Values.minimumMasterNodes }}"
+            value: "{{ .Values.elasticsearch.minimumMasterNodes }}"
           {{- end }}
           {{- end }}
           {{- if lt (int (include "elasticsearch.esMajorVersion" .)) 7 }}
@@ -286,61 +286,61 @@ spec:
             value: "{{ .Release.Name }}-elasticsearch"
           {{- end }}
           - name: cluster.name
-            value: "{{ .Values.clusterName }}"
+            value: "{{ .Values.elasticsearch.clusterName }}"
           - name: network.host
-            value: "{{ .Values.networkHost }}"
+            value: "{{ .Values.elasticsearch.networkHost }}"
           - name: ES_JAVA_OPTS
-            value: "{{ .Values.esJavaOpts }}"
-          {{- range $role, $enabled := .Values.roles }}
+            value: "{{ .Values.elasticsearch.esJavaOpts }}"
+          {{- range $role, $enabled := .Values.elasticsearch.roles }}
           - name: node.{{ $role }}
             value: "{{ $enabled }}"
           {{- end }}
-{{- if .Values.extraEnvs }}
-{{ toYaml .Values.extraEnvs | indent 10 }}
+{{- if .Values.elasticsearch.extraEnvs }}
+{{ toYaml .Values.elasticsearch.extraEnvs | indent 10 }}
 {{- end }}
-{{- if .Values.envFrom }}
+{{- if .Values.elasticsearch.envFrom }}
         envFrom:
-{{ toYaml .Values.envFrom | indent 10 }}
+{{ toYaml .Values.elasticsearch.envFrom | indent 10 }}
 {{- end }}
         volumeMounts:
-          {{- if .Values.persistence.enabled }}
+          {{- if .Values.k8s.persistence.enabled }}
           - name: "{{ template "elasticsearch.uname" . }}"
             mountPath: /usr/share/elasticsearch/data
           {{- end }}
-{{ if .Values.keystore }}
+{{ if .Values.elasticsearch.keystore }}
           - name: keystore
             mountPath: /usr/share/elasticsearch/config/elasticsearch.keystore
             subPath: elasticsearch.keystore
 {{ end }}
-          {{- range .Values.secretMounts }}
+          {{- range .Values.elasticsearch.secretMounts }}
           - name: {{ .name }}
             mountPath: {{ .path }}
             {{- if .subPath }}
             subPath: {{ .subPath }}
             {{- end }}
           {{- end }}
-          {{- range $path, $config := .Values.esConfig }}
+          {{- range $path, $config := .Values.elasticsearch.esConfig }}
           - name: esconfig
             mountPath: /usr/share/elasticsearch/config/{{ $path }}
             subPath: {{ $path }}
           {{- end -}}
-        {{- if .Values.extraVolumeMounts }}
+        {{- if .Values.elasticsearch.extraVolumeMounts }}
         # Currently some extra blocks accept strings
         # to continue with backwards compatibility this is being kept
         # whilst also allowing for yaml to be specified too.
-        {{- if eq "string" (printf "%T" .Values.extraVolumeMounts) }}
-{{ tpl .Values.extraVolumeMounts . | indent 10 }}
+        {{- if eq "string" (printf "%T" .Values.elasticsearch.extraVolumeMounts) }}
+{{ tpl .Values.elasticsearch.extraVolumeMounts . | indent 10 }}
         {{- else }}
-{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+{{ toYaml .Values.elasticsearch.extraVolumeMounts | indent 10 }}
         {{- end }}
         {{- end }}
-      {{- if .Values.masterTerminationFix }}
-      {{- if eq .Values.roles.master "true" }}
+      {{- if .Values.elasticsearch.masterTerminationFix }}
+      {{- if eq .Values.elasticsearch.roles.master "true" }}
       # This sidecar will prevent slow master re-election
       # https://github.com/elastic/helm-charts/issues/63
       - name: elasticsearch-master-graceful-termination-handler
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        image: "{{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.imageTag }}"
+        imagePullPolicy: "{{ .Values.elasticsearch.imagePullPolicy }}"
         command:
         - "sh"
         - -c
@@ -355,7 +355,7 @@ spec:
               else
                 BASIC_AUTH=''
               fi
-              curl -XGET -s -k --fail ${BASIC_AUTH} {{ .Values.protocol }}://{{ template "elasticsearch.masterService" . }}:{{ .Values.httpPort }}${path}
+              curl -XGET -s -k --fail ${BASIC_AUTH} {{ .Values.elasticsearch.protocol }}://{{ template "elasticsearch.masterService" . }}:{{ .Values.elasticsearch.httpPort }}${path}
           }
 
           cleanup () {
@@ -377,32 +377,32 @@ spec:
           sleep infinity &
           wait $!
         resources:
-{{ toYaml .Values.sidecarResources | indent 10 }}
+{{ toYaml .Values.elasticsearch.sidecarResources | indent 10 }}
         env:
           - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-        {{- if .Values.extraEnvs }}
-{{ toYaml .Values.extraEnvs | indent 10 }}
+        {{- if .Values.elasticsearch.extraEnvs }}
+{{ toYaml .Values.elasticsearch.extraEnvs | indent 10 }}
         {{- end }}
-        {{- if .Values.envFrom }}
+        {{- if .Values.elasticsearch.envFrom }}
         envFrom:
-{{ toYaml .Values.envFrom | indent 10 }}
+{{ toYaml .Values.elasticsearch.envFrom | indent 10 }}
         {{- end }}
       {{- end }}
       {{- end }}
-{{- if .Values.lifecycle }}
+{{- if .Values.elasticsearch.lifecycle }}
         lifecycle:
-{{ toYaml .Values.lifecycle | indent 10 }}
+{{ toYaml .Values.elasticsearch.lifecycle | indent 10 }}
 {{- end }}
-      {{- if .Values.extraContainers }}
+      {{- if .Values.elasticsearch.extraContainers }}
       # Currently some extra blocks accept strings
       # to continue with backwards compatibility this is being kept
       # whilst also allowing for yaml to be specified too.
-      {{- if eq "string" (printf "%T" .Values.extraContainers) }}
-{{ tpl .Values.extraContainers . | indent 6 }}
+      {{- if eq "string" (printf "%T" .Values.elasticsearch.extraContainers) }}
+{{ tpl .Values.elasticsearch.extraContainers . | indent 6 }}
       {{- else }}
-{{ toYaml .Values.extraContainers | indent 6 }}
+{{ toYaml .Values.elasticsearch.extraContainers | indent 6 }}
       {{- end }}
       {{- end }}

--- a/helm/openwhisk/templates/elasticsearch-psp.yaml
+++ b/helm/openwhisk/templates/elasticsearch-psp.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podSecurityPolicy.create -}}
+{{- $fullName := include "elasticsearch.uname" . -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ default $fullName .Values.podSecurityPolicy.name | quote }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+spec:
+{{ toYaml .Values.podSecurityPolicy.spec | indent 2 }}
+{{- end -}}

--- a/helm/openwhisk/templates/elasticsearch-psp.yaml
+++ b/helm/openwhisk/templates/elasticsearch-psp.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 {{- if and .Values.elasticsearch.podSecurityPolicy.create (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: policy/v1beta1

--- a/helm/openwhisk/templates/elasticsearch-psp.yaml
+++ b/helm/openwhisk/templates/elasticsearch-psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.elasticsearch.podSecurityPolicy.create -}}
+{{- if and .Values.elasticsearch.podSecurityPolicy.create (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/helm/openwhisk/templates/elasticsearch-psp.yaml
+++ b/helm/openwhisk/templates/elasticsearch-psp.yaml
@@ -1,14 +1,11 @@
-{{- if .Values.podSecurityPolicy.create -}}
+{{- if .Values.elasticsearch.podSecurityPolicy.create -}}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ default $fullName .Values.podSecurityPolicy.name | quote }}
+  name: {{ default $fullName .Values.elasticsearch.podSecurityPolicy.name | quote }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app: {{ $fullName | quote }}
+{{ include "openwhisk.label_boilerplate" .| indent 4 }}
 spec:
-{{ toYaml .Values.podSecurityPolicy.spec | indent 2 }}
+{{ toYaml .Values.elasticsearch.podSecurityPolicy.spec | indent 2 }}
 {{- end -}}

--- a/helm/openwhisk/templates/elasticsearch-role.yaml
+++ b/helm/openwhisk/templates/elasticsearch-role.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbac.create -}}
+{{- $fullName := include "elasticsearch.uname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName | quote }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      {{- if eq .Values.podSecurityPolicy.name "" }}
+      - {{ $fullName | quote }}
+      {{- else }}
+      - {{ .Values.podSecurityPolicy.name | quote }}
+      {{- end }}
+    verbs:
+      - use
+{{- end -}}

--- a/helm/openwhisk/templates/elasticsearch-role.yaml
+++ b/helm/openwhisk/templates/elasticsearch-role.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 {{- if and .Values.elasticsearch.rbac.create (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/openwhisk/templates/elasticsearch-role.yaml
+++ b/helm/openwhisk/templates/elasticsearch-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.elasticsearch.rbac.create -}}
+{{- if and .Values.elasticsearch.rbac.create (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/helm/openwhisk/templates/elasticsearch-role.yaml
+++ b/helm/openwhisk/templates/elasticsearch-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.elasticsearch.rbac.create -}}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -12,10 +12,10 @@ rules:
     resources:
       - podsecuritypolicies
     resourceNames:
-      {{- if eq .Values.podSecurityPolicy.name "" }}
+      {{- if eq .Values.elasticsearch.podSecurityPolicy.name "" }}
       - {{ $fullName | quote }}
       {{- else }}
-      - {{ .Values.podSecurityPolicy.name | quote }}
+      - {{ .Values.elasticsearch.podSecurityPolicy.name | quote }}
       {{- end }}
     verbs:
       - use

--- a/helm/openwhisk/templates/elasticsearch-role.yaml
+++ b/helm/openwhisk/templates/elasticsearch-role.yaml
@@ -3,12 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ $fullName | quote }}
+  name: {{ .Release.Name }}-elasticsearch
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app: {{ $fullName | quote }}
+{{ include "openwhisk.label_boilerplate" . | indent 4 }}
 rules:
   - apiGroups:
       - extensions

--- a/helm/openwhisk/templates/elasticsearch-rolebind.yaml
+++ b/helm/openwhisk/templates/elasticsearch-rolebind.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create -}}
+{{- $fullName := include "elasticsearch.uname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName | quote }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+subjects:
+  - kind: ServiceAccount
+    {{- if eq .Values.rbac.serviceAccountName "" }}
+    name: {{ $fullName | quote }}
+    {{- else }}
+    name: {{ .Values.rbac.serviceAccountName | quote }}
+    {{- end }}
+    namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ $fullName | quote }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/helm/openwhisk/templates/elasticsearch-rolebind.yaml
+++ b/helm/openwhisk/templates/elasticsearch-rolebind.yaml
@@ -3,12 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ $fullName | quote }}
+  name: {{ .Release.Name }}-elasticsearch
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app: {{ $fullName | quote }}
+{{ include "openwhisk.label_boilerplate" . | indent 4 }}
 subjects:
   - kind: ServiceAccount
     {{- if eq .Values.rbac.serviceAccountName "" }}

--- a/helm/openwhisk/templates/elasticsearch-rolebind.yaml
+++ b/helm/openwhisk/templates/elasticsearch-rolebind.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.elasticsearch.rbac.create -}}
+{{- if and .Values.elasticsearch.rbac.create (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/openwhisk/templates/elasticsearch-rolebind.yaml
+++ b/helm/openwhisk/templates/elasticsearch-rolebind.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 {{- if and .Values.elasticsearch.rbac.create (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/openwhisk/templates/elasticsearch-rolebind.yaml
+++ b/helm/openwhisk/templates/elasticsearch-rolebind.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.elasticsearch.rbac.create -}}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -8,10 +8,10 @@ metadata:
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 subjects:
   - kind: ServiceAccount
-    {{- if eq .Values.rbac.serviceAccountName "" }}
+    {{- if eq .Values.elasticsearch.rbac.serviceAccountName "" }}
     name: {{ $fullName | quote }}
     {{- else }}
-    name: {{ .Values.rbac.serviceAccountName | quote }}
+    name: {{ .Values.elasticsearch.rbac.serviceAccountName | quote }}
     {{- end }}
     namespace: {{ .Release.Namespace | quote }}
 roleRef:

--- a/helm/openwhisk/templates/elasticsearch-svc.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svc.yaml
@@ -1,0 +1,72 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+{{- if eq .Values.nodeGroup "master" }}
+  name: {{ template "elasticsearch.masterService" . }}
+{{- else }}
+  name: {{ template "elasticsearch.uname" . }}
+{{- end }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    app: "{{ template "elasticsearch.uname" . }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4}}
+{{- end }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    app: "{{ template "elasticsearch.uname" . }}"
+  ports:
+  - name: {{ .Values.service.httpPortName | default "http" }}
+    protocol: TCP
+    port: {{ .Values.httpPort }}
+{{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+  - name: {{ .Values.service.transportPortName | default "transport" }}
+    protocol: TCP
+    port: {{ .Values.transportPort }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
+{{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml . | indent 4 }}
+{{- end }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+{{- if eq .Values.nodeGroup "master" }}
+  name: {{ template "elasticsearch.masterService" . }}-headless
+{{- else }}
+  name: {{ template "elasticsearch.uname" . }}-headless
+{{- end }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    app: "{{ template "elasticsearch.uname" . }}"
+{{- if .Values.service.labelsHeadless }}
+{{ toYaml .Values.service.labelsHeadless | indent 4 }}
+{{- end }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like elasticsearch-0 to resolve
+  # Create endpoints also if the related pod isn't ready
+  publishNotReadyAddresses: true
+  selector:
+    app: "{{ template "elasticsearch.uname" . }}"
+  ports:
+  - name: {{ .Values.service.httpPortName | default "http" }}
+    port: {{ .Values.httpPort }}
+  - name: {{ .Values.service.transportPortName | default "transport" }}
+    port: {{ .Values.transportPort }}

--- a/helm/openwhisk/templates/elasticsearch-svc.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svc.yaml
@@ -2,27 +2,14 @@
 kind: Service
 apiVersion: v1
 metadata:
-{{- if eq .Values.nodeGroup "master" }}
-  name: {{ template "elasticsearch.masterService" . }}
-{{- else }}
-  name: {{ template "elasticsearch.uname" . }}
-{{- end }}
+  name: {{ .Release.Name }}-elasticsearch
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
-{{- if .Values.service.labels }}
-{{ toYaml .Values.service.labels | indent 4}}
-{{- end }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+    name: {{ .Release.Name }}-elasticsearch
+{{ include "openwhisk.label_boilerplate" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   selector:
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
+    name: {{ .Release.Name }}-elasticsearch
   ports:
   - name: {{ .Values.service.httpPortName | default "http" }}
     protocol: TCP
@@ -45,15 +32,12 @@ kind: Service
 apiVersion: v1
 metadata:
 {{- if eq .Values.nodeGroup "master" }}
-  name: {{ template "elasticsearch.masterService" . }}-headless
+  name: {{ .Release.Name }}-elasticsearch-headless
 {{- else }}
-  name: {{ template "elasticsearch.uname" . }}-headless
+  name: {{ .Release.Name }}-elasticsearch-headless
 {{- end }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
+{{ include "openwhisk.label_boilerplate" . | indent 4 }}
 {{- if .Values.service.labelsHeadless }}
 {{ toYaml .Values.service.labelsHeadless | indent 4 }}
 {{- end }}
@@ -64,7 +48,7 @@ spec:
   # Create endpoints also if the related pod isn't ready
   publishNotReadyAddresses: true
   selector:
-    app: "{{ template "elasticsearch.uname" . }}"
+    name: {{ .Release.Name }}-elasticsearch
   ports:
   - name: {{ .Values.service.httpPortName | default "http" }}
     port: {{ .Values.httpPort }}

--- a/helm/openwhisk/templates/elasticsearch-svc.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svc.yaml
@@ -1,3 +1,4 @@
+{{- if and (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 ---
 kind: Service
 apiVersion: v1
@@ -22,3 +23,4 @@ spec:
     port: {{ .Values.elasticsearch.httpPort }}
   - name: {{ .Values.elasticsearch.service.transportPortName | default "transport" }}
     port: {{ .Values.elasticsearch.transportPort }}
+{{- end -}}

--- a/helm/openwhisk/templates/elasticsearch-svc.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svc.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 {{- if and (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 ---
 kind: Service

--- a/helm/openwhisk/templates/elasticsearch-svc.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svc.yaml
@@ -6,38 +6,6 @@ metadata:
   labels:
     name: {{ .Release.Name }}-elasticsearch
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
-spec:
-  type: {{ .Values.service.type }}
-  selector:
-    name: {{ .Release.Name }}-elasticsearch
-  ports:
-  - name: {{ .Values.service.httpPortName | default "http" }}
-    protocol: TCP
-    port: {{ .Values.httpPort }}
-{{- if .Values.service.nodePort }}
-    nodePort: {{ .Values.service.nodePort }}
-{{- end }}
-  - name: {{ .Values.service.transportPortName | default "transport" }}
-    protocol: TCP
-    port: {{ .Values.transportPort }}
-{{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
-{{- end }}
-{{- with .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-{{ toYaml . | indent 4 }}
-{{- end }}
----
-kind: Service
-apiVersion: v1
-metadata:
-{{- if eq .Values.nodeGroup "master" }}
-  name: {{ .Release.Name }}-elasticsearch-headless
-{{- else }}
-  name: {{ .Release.Name }}-elasticsearch-headless
-{{- end }}
-  labels:
-{{ include "openwhisk.label_boilerplate" . | indent 4 }}
 {{- if .Values.service.labelsHeadless }}
 {{ toYaml .Values.service.labelsHeadless | indent 4 }}
 {{- end }}

--- a/helm/openwhisk/templates/elasticsearch-svc.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svc.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     name: {{ .Release.Name }}-elasticsearch
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
-{{- if .Values.service.labelsHeadless }}
-{{ toYaml .Values.service.labelsHeadless | indent 4 }}
+{{- if .Values.elasticsearch.service.labelsHeadless }}
+{{ toYaml .Values.elasticsearch.service.labelsHeadless | indent 4 }}
 {{- end }}
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -18,7 +18,7 @@ spec:
   selector:
     name: {{ .Release.Name }}-elasticsearch
   ports:
-  - name: {{ .Values.service.httpPortName | default "http" }}
-    port: {{ .Values.httpPort }}
-  - name: {{ .Values.service.transportPortName | default "transport" }}
-    port: {{ .Values.transportPort }}
+  - name: {{ .Values.elasticsearch.service.httpPortName | default "http" }}
+    port: {{ .Values.elasticsearch.httpPort }}
+  - name: {{ .Values.elasticsearch.service.transportPortName | default "transport" }}
+    port: {{ .Values.elasticsearch.transportPort }}

--- a/helm/openwhisk/templates/elasticsearch-svcacct.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svcacct.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+{{- $fullName := include "elasticsearch.uname" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- if eq .Values.rbac.serviceAccountName "" }}
+  name: {{ $fullName | quote }}
+  {{- else }}
+  name: {{ .Values.rbac.serviceAccountName | quote }}
+  {{- end }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ $fullName | quote }}
+{{- end -}}

--- a/helm/openwhisk/templates/elasticsearch-svcacct.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svcacct.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.elasticsearch.rbac.create -}}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- if eq .Values.rbac.serviceAccountName "" }}
+  {{- if eq .Values.elasticsearch.rbac.serviceAccountName "" }}
   name: {{ $fullName | quote }}
   {{- else }}
-  name: {{ .Values.rbac.serviceAccountName | quote }}
+  name: {{ .Values.elasticsearch.rbac.serviceAccountName | quote }}
   {{- end }}
   labels:
     heritage: {{ .Release.Service | quote }}

--- a/helm/openwhisk/templates/elasticsearch-svcacct.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svcacct.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.elasticsearch.rbac.create -}}
+{{- if and .Values.elasticsearch.rbac.create (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/openwhisk/templates/elasticsearch-svcacct.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svcacct.yaml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 {{- if and .Values.elasticsearch.rbac.create (not .Values.elasticsearch.external) (eq .Values.activationStoreBackend "ElasticSearch") }}
 {{- $fullName := include "elasticsearch.uname" . -}}
 apiVersion: v1

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -189,6 +189,20 @@ spec:
           - name: "CONFIG_whisk_userEvents_enabled"
             value: "true"
 {{ end }}
+{{- if eq .Values.activationStoreBackend "ElasticSearch" }}
+          - name: "CONFIG_whisk_activationStore_elasticsearch_protocol"
+            value: "{{ .Values.protocol }}"
+          - name: "CONFIG_whisk_activationStore_elasticsearch_hosts"
+            value: {{ template "openwhisk.elasticsearch_connect" . }}
+          - name: "CONFIG_whisk_activationStore_elasticsearch_indexPattern"
+            value: {{ .Values.indexPattern }}
+          - name: "CONFIG_whisk_activationStore_elasticsearch_username"
+            value: "admin"
+          - name: "CONFIG_whisk_activationStore_elasticsearch_password"
+            value: "admin"
+          - name: "CONFIG_whisk_spi_ActivationStoreProvider"
+            value: "org.apache.openwhisk.core.database.elasticsearch.ElasticSearchActivationStoreProvider"
+{{- end }}
         ports:
         - name: invoker
           containerPort: {{ .Values.invoker.port }}

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -191,15 +191,15 @@ spec:
 {{ end }}
 {{- if eq .Values.activationStoreBackend "ElasticSearch" }}
           - name: "CONFIG_whisk_activationStore_elasticsearch_protocol"
-            value: "{{ .Values.protocol }}"
+            value: "{{ .Values.elasticsearch.protocol }}"
           - name: "CONFIG_whisk_activationStore_elasticsearch_hosts"
             value: {{ template "openwhisk.elasticsearch_connect" . }}
           - name: "CONFIG_whisk_activationStore_elasticsearch_indexPattern"
-            value: {{ .Values.indexPattern }}
+            value: {{ .Values.elasticsearch.indexPattern }}
           - name: "CONFIG_whisk_activationStore_elasticsearch_username"
-            value: "admin"
+            value: "{{ .Values.elasticsearch.username }}"
           - name: "CONFIG_whisk_activationStore_elasticsearch_password"
-            value: "admin"
+            value: "{{ .Values.elasticsearch.password }}"
           - name: "CONFIG_whisk_spi_ActivationStoreProvider"
             value: "org.apache.openwhisk.core.database.elasticsearch.ElasticSearchActivationStoreProvider"
 {{- end }}

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -536,7 +536,7 @@ secretMounts: []
 #    defaultMode: 0755
 
 image: "docker.elastic.co/elasticsearch/elasticsearch"
-imageTag: "7.8.0"
+imageTag: "6.7.2"
 imagePullPolicy: "IfNotPresent"
 
 podAnnotations: {}
@@ -756,3 +756,6 @@ keystore: []
 # Deprecated
 # please use the above podSecurityContext.fsGroup instead
 fsGroup: ""
+
+activationStoreBackend: "ElasticSearch"
+indexPattern: "openwhisk-%s"

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -483,3 +483,276 @@ pdb:
     maxUnavailable: 1
   invoker:
     maxUnavailable: 1
+
+clusterName: "elasticsearch"
+nodeGroup: "master"
+
+# The service that non master groups will try to connect to when joining the cluster
+# This should be set to clusterName + "-" + nodeGroup for your master group
+masterService: ""
+
+# Elasticsearch roles that will be applied to this nodeGroup
+# These will be set as environment variables. E.g. node.master=true
+roles:
+  master: "true"
+  ingest: "true"
+  data: "true"
+
+replicas: 3
+minimumMasterNodes: 2
+
+esMajorVersion: ""
+
+# Allows you to add any config files in /usr/share/elasticsearch/config/
+# such as elasticsearch.yml and log4j2.properties
+esConfig: {}
+#  elasticsearch.yml: |
+#    key:
+#      nestedkey: value
+#  log4j2.properties: |
+#    key = value
+
+# Extra environment variables to append to this nodeGroup
+# This will be appended to the current 'env:' key. You can use any of the kubernetes env
+# syntax here
+extraEnvs: []
+#  - name: MY_ENVIRONMENT_VAR
+#    value: the_value_goes_here
+
+# Allows you to load environment variables from kubernetes secret or config map
+envFrom: []
+# - secretRef:
+#     name: env-secret
+# - configMapRef:
+#     name: config-map
+
+# A list of secrets and their paths to mount inside the pod
+# This is useful for mounting certificates for security and for mounting
+# the X-Pack license
+secretMounts: []
+#  - name: elastic-certificates
+#    secretName: elastic-certificates
+#    path: /usr/share/elasticsearch/config/certs
+#    defaultMode: 0755
+
+image: "docker.elastic.co/elasticsearch/elasticsearch"
+imageTag: "7.8.0"
+imagePullPolicy: "IfNotPresent"
+
+podAnnotations: {}
+  # iam.amazonaws.com/role: es-cluster
+
+# additionals labels
+labels: {}
+
+esJavaOpts: "-Xmx1g -Xms1g"
+
+resources:
+  requests:
+    cpu: "1000m"
+    memory: "2Gi"
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"
+
+initResources: {}
+  # limits:
+  #   cpu: "25m"
+  #   # memory: "128Mi"
+  # requests:
+  #   cpu: "25m"
+  #   memory: "128Mi"
+
+sidecarResources: {}
+  # limits:
+  #   cpu: "25m"
+  #   # memory: "128Mi"
+  # requests:
+  #   cpu: "25m"
+  #   memory: "128Mi"
+
+networkHost: "0.0.0.0"
+
+volumeClaimTemplate:
+  accessModes: [ "ReadWriteOnce" ]
+  resources:
+    requests:
+      storage: 30Gi
+
+rbac:
+  create: false
+  serviceAccountName: ""
+
+podSecurityPolicy:
+  create: false
+  name: ""
+  spec:
+    privileged: true
+    fsGroup:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    volumes:
+      - secret
+      - configMap
+      - persistentVolumeClaim
+
+persistence:
+  enabled: true
+  annotations: {}
+
+extraVolumes: []
+  # - name: extras
+  #   emptyDir: {}
+
+extraVolumeMounts: []
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+
+extraContainers: []
+  # - name: do-something
+  #   image: busybox
+  #   command: ['do', 'something']
+
+extraInitContainers: []
+  # - name: do-something
+  #   image: busybox
+  #   command: ['do', 'something']
+
+# This is the PriorityClass settings as defined in
+# https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: ""
+
+# By default this will make sure two pods don't end up on the same node
+# Changing this to a region would allow you to spread pods across regions
+antiAffinityTopologyKey: "kubernetes.io/hostname"
+
+# Hard means that by default pods will only be scheduled if there are enough nodes for them
+# and that they will never end up on the same node. Setting this to soft will do this "best effort"
+antiAffinity: "hard"
+
+# This is the node affinity settings as defined in
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+nodeAffinity: {}
+
+# The default is to deploy all pods serially. By setting this to parallel all pods are started at
+# the same time when bootstrapping the cluster
+podManagementPolicy: "Parallel"
+
+# The environment variables injected by service links are not used, but can lead to slow Elasticsearch boot times when
+# there are many services in the current namespace.
+# If you experience slow pod startups you probably want to set this to `false`.
+enableServiceLinks: true
+
+protocol: http
+httpPort: 9200
+transportPort: 9300
+
+service:
+  labels: {}
+  labelsHeadless: {}
+  type: ClusterIP
+  nodePort: ""
+  annotations: {}
+  httpPortName: http
+  transportPortName: transport
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+
+updateStrategy: RollingUpdate
+
+# This is the max unavailable setting for the pod disruption budget
+# The default value of 1 will make sure that kubernetes won't allow more than 1
+# of your pods to be unavailable during maintenance
+maxUnavailable: 1
+
+podSecurityContext:
+  fsGroup: 1000
+  runAsUser: 1000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  # readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# How long to wait for elasticsearch to stop gracefully
+terminationGracePeriod: 120
+
+sysctlVmMaxMapCount: 262144
+
+readinessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 3
+  timeoutSeconds: 5
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/7.8/cluster-health.html#request-params wait_for_status
+clusterHealthCheckParams: "wait_for_status=green&timeout=1s"
+
+## Use an alternate scheduler.
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+schedulerName: ""
+
+imagePullSecrets: []
+nodeSelector: {}
+tolerations: []
+
+# Enabling this will publically expose your Elasticsearch instance.
+# Only enable this if you have security enabled on your cluster
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+nameOverride: ""
+fullnameOverride: ""
+
+# https://github.com/elastic/helm-charts/issues/63
+masterTerminationFix: false
+
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+  # postStart:
+  #   exec:
+  #     command:
+  #       - bash
+  #       - -c
+  #       - |
+  #         #!/bin/bash
+  #         # Add a template to adjust number of shards/replicas
+  #         TEMPLATE_NAME=my_template
+  #         INDEX_PATTERN="logstash-*"
+  #         SHARD_COUNT=8
+  #         REPLICA_COUNT=1
+  #         ES_URL=http://localhost:9200
+  #         while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' $ES_URL)" != "200" ]]; do sleep 1; done
+  #         curl -XPUT "$ES_URL/_template/$TEMPLATE_NAME" -H 'Content-Type: application/json' -d'{"index_patterns":['\""$INDEX_PATTERN"\"'],"settings":{"number_of_shards":'$SHARD_COUNT',"number_of_replicas":'$REPLICA_COUNT'}}'
+
+sysctlInitContainer:
+  enabled: true
+
+keystore: []
+
+# Deprecated
+# please use the above podSecurityContext.fsGroup instead
+fsGroup: ""

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -229,6 +229,8 @@ db:
   persistence:
     size: 2Gi
 
+activationStoreBackend: "ElasticSearch"
+
 # Nginx configurations
 nginx:
   imageName: "nginx"
@@ -483,281 +485,200 @@ pdb:
     maxUnavailable: 1
   invoker:
     maxUnavailable: 1
+  elasticsearch:
+    maxUnavailable: 1
 
-clusterName: "elasticsearch"
-nodeGroup: "master"
-
-# The service that non master groups will try to connect to when joining the cluster
-# This should be set to clusterName + "-" + nodeGroup for your master group
-masterService: ""
-
-# Elasticsearch roles that will be applied to this nodeGroup
-# These will be set as environment variables. E.g. node.master=true
-roles:
-  master: "true"
-  ingest: "true"
-  data: "true"
-
-replicas: 3
-minimumMasterNodes: 2
-
-esMajorVersion: ""
-
-# Allows you to add any config files in /usr/share/elasticsearch/config/
-# such as elasticsearch.yml and log4j2.properties
-esConfig: {}
-#  elasticsearch.yml: |
-#    key:
-#      nestedkey: value
-#  log4j2.properties: |
-#    key = value
-
-# Extra environment variables to append to this nodeGroup
-# This will be appended to the current 'env:' key. You can use any of the kubernetes env
-# syntax here
-extraEnvs: []
-#  - name: MY_ENVIRONMENT_VAR
-#    value: the_value_goes_here
-
-# Allows you to load environment variables from kubernetes secret or config map
-envFrom: []
-# - secretRef:
-#     name: env-secret
-# - configMapRef:
-#     name: config-map
-
-# A list of secrets and their paths to mount inside the pod
-# This is useful for mounting certificates for security and for mounting
-# the X-Pack license
-secretMounts: []
-#  - name: elastic-certificates
-#    secretName: elastic-certificates
-#    path: /usr/share/elasticsearch/config/certs
-#    defaultMode: 0755
-
-image: "docker.elastic.co/elasticsearch/elasticsearch"
-imageTag: "6.7.2"
-imagePullPolicy: "IfNotPresent"
-
-podAnnotations: {}
-  # iam.amazonaws.com/role: es-cluster
-
-# additionals labels
-labels: {}
-
-esJavaOpts: "-Xmx1g -Xms1g"
-
-resources:
-  requests:
-    cpu: "1000m"
-    memory: "2Gi"
-  limits:
-    cpu: "1000m"
-    memory: "2Gi"
-
-initResources: {}
-  # limits:
-  #   cpu: "25m"
-  #   # memory: "128Mi"
-  # requests:
-  #   cpu: "25m"
-  #   memory: "128Mi"
-
-sidecarResources: {}
-  # limits:
-  #   cpu: "25m"
-  #   # memory: "128Mi"
-  # requests:
-  #   cpu: "25m"
-  #   memory: "128Mi"
-
-networkHost: "0.0.0.0"
-
-volumeClaimTemplate:
-  accessModes: [ "ReadWriteOnce" ]
+# ElasticSearch configuration
+elasticsearch:
+  external: false
+  clusterName: "elasticsearch"
+  nodeGroup: "master"
+  # The service that non master groups will try to connect to when joining the cluster
+  # This should be set to clusterName + "-" + nodeGroup for your master group
+  masterServiceValue: ""
+  # Elasticsearch roles that will be applied to this nodeGroup
+  # These will be set as environment variables. E.g. node.master=true
+  roles:
+    master: "true"
+    ingest: "true"
+    data: "true"
+  replicaCount: 1
+  minimumMasterNodes: 1
+  esMajorVersionValue: ""
+  # Allows you to add any config files in /usr/share/elasticsearch/config/
+  # such as elasticsearch.yml and log4j2.properties, e.g.
+  #  elasticsearch.yml: |
+  #    key:
+  #      nestedkey: value
+  #  log4j2.properties: |
+  #    key = value
+  esConfig: {}
+  # Extra environment variables to append to this nodeGroup
+  # This will be appended to the current 'env:' key. You can use any of the kubernetes env
+  # syntax here
+  #  - name: MY_ENVIRONMENT_VAR
+  #    value: the_value_goes_here
+  extraEnvs: []
+  # Allows you to load environment variables from kubernetes secret or config map
+  # - secretRef:
+  #     name: env-secret
+  # - configMapRef:
+  #     name: config-map
+  envFrom: []
+  # A list of secrets and their paths to mount inside the pod
+  # This is useful for mounting certificates for security and for mounting
+  # the X-Pack license
+  #  - name: elastic-certificates
+  #    secretName: elastic-certificates
+  #    path: /usr/share/elasticsearch/config/certs
+  #    defaultMode: 0755
+  secretMounts: []
+  image: "docker.elastic.co/elasticsearch/elasticsearch"
+  imageTag: "6.7.2"
+  imagePullPolicy: "IfNotPresent"
+  podAnnotations: {}
+  labels: {}
+  esJavaOpts: "-Xmx1g -Xms1g"
   resources:
     requests:
-      storage: 30Gi
-
-rbac:
-  create: false
-  serviceAccountName: ""
-
-podSecurityPolicy:
-  create: false
-  name: ""
-  spec:
-    privileged: true
-    fsGroup:
-      rule: RunAsAny
-    runAsUser:
-      rule: RunAsAny
-    seLinux:
-      rule: RunAsAny
-    supplementalGroups:
-      rule: RunAsAny
-    volumes:
-      - secret
-      - configMap
-      - persistentVolumeClaim
-
-persistence:
-  enabled: true
-  annotations: {}
-
-extraVolumes: []
-  # - name: extras
-  #   emptyDir: {}
-
-extraVolumeMounts: []
+      cpu: "1000m"
+      memory: "2Gi"
+    limits:
+      cpu: "1000m"
+      memory: "2Gi"
+  initResources: {}
+  sidecarResources: {}
+  networkHost: "0.0.0.0"
+  volumeClaimTemplate:
+    accessModes: [ "ReadWriteOnce" ]
+    resources:
+      requests:
+        storage: 30Gi
+  rbac:
+    create: false
+    serviceAccountName: ""
+  podSecurityPolicy:
+    create: false
+    name: ""
+    spec:
+      privileged: true
+      fsGroup:
+        rule: RunAsAny
+      runAsUser:
+        rule: RunAsAny
+      seLinux:
+        rule: RunAsAny
+      supplementalGroups:
+        rule: RunAsAny
+      volumes:
+        - secret
+        - configMap
+        - persistentVolumeClaim
+  persistence:
+    annotations: {}
+  extraVolumes: []
   # - name: extras
   #   mountPath: /usr/share/extras
   #   readOnly: true
-
-extraContainers: []
+  extraVolumeMounts: []
   # - name: do-something
   #   image: busybox
   #   command: ['do', 'something']
-
-extraInitContainers: []
+  extraContainers: []
   # - name: do-something
   #   image: busybox
   #   command: ['do', 'something']
-
-# This is the PriorityClass settings as defined in
-# https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-priorityClassName: ""
-
-# By default this will make sure two pods don't end up on the same node
-# Changing this to a region would allow you to spread pods across regions
-antiAffinityTopologyKey: "kubernetes.io/hostname"
-
-# Hard means that by default pods will only be scheduled if there are enough nodes for them
-# and that they will never end up on the same node. Setting this to soft will do this "best effort"
-antiAffinity: "hard"
-
-# This is the node affinity settings as defined in
-# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
-nodeAffinity: {}
-
-# The default is to deploy all pods serially. By setting this to parallel all pods are started at
-# the same time when bootstrapping the cluster
-podManagementPolicy: "Parallel"
-
-# The environment variables injected by service links are not used, but can lead to slow Elasticsearch boot times when
-# there are many services in the current namespace.
-# If you experience slow pod startups you probably want to set this to `false`.
-enableServiceLinks: true
-
-protocol: http
-httpPort: 9200
-transportPort: 9300
-
-service:
-  labels: {}
-  labelsHeadless: {}
-  type: ClusterIP
-  nodePort: ""
-  annotations: {}
-  httpPortName: http
-  transportPortName: transport
-  loadBalancerIP: ""
-  loadBalancerSourceRanges: []
-
-updateStrategy: RollingUpdate
-
-# This is the max unavailable setting for the pod disruption budget
-# The default value of 1 will make sure that kubernetes won't allow more than 1
-# of your pods to be unavailable during maintenance
-maxUnavailable: 1
-
-podSecurityContext:
-  fsGroup: 1000
-  runAsUser: 1000
-
-securityContext:
-  capabilities:
-    drop:
-    - ALL
-  # readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 1000
-
-# How long to wait for elasticsearch to stop gracefully
-terminationGracePeriod: 120
-
-sysctlVmMaxMapCount: 262144
-
-readinessProbe:
-  failureThreshold: 3
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  successThreshold: 3
-  timeoutSeconds: 5
-
-# https://www.elastic.co/guide/en/elasticsearch/reference/7.8/cluster-health.html#request-params wait_for_status
-clusterHealthCheckParams: "wait_for_status=green&timeout=1s"
-
-## Use an alternate scheduler.
-## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
-##
-schedulerName: ""
-
-imagePullSecrets: []
-nodeSelector: {}
-tolerations: []
-
-# Enabling this will publically expose your Elasticsearch instance.
-# Only enable this if you have security enabled on your cluster
-ingress:
-  enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  path: /
-  hosts:
-    - chart-example.local
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-nameOverride: ""
-fullnameOverride: ""
-
-# https://github.com/elastic/helm-charts/issues/63
-masterTerminationFix: false
-
-lifecycle: {}
-  # preStop:
-  #   exec:
-  #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
-  # postStart:
-  #   exec:
-  #     command:
-  #       - bash
-  #       - -c
-  #       - |
-  #         #!/bin/bash
-  #         # Add a template to adjust number of shards/replicas
-  #         TEMPLATE_NAME=my_template
-  #         INDEX_PATTERN="logstash-*"
-  #         SHARD_COUNT=8
-  #         REPLICA_COUNT=1
-  #         ES_URL=http://localhost:9200
-  #         while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' $ES_URL)" != "200" ]]; do sleep 1; done
-  #         curl -XPUT "$ES_URL/_template/$TEMPLATE_NAME" -H 'Content-Type: application/json' -d'{"index_patterns":['\""$INDEX_PATTERN"\"'],"settings":{"number_of_shards":'$SHARD_COUNT',"number_of_replicas":'$REPLICA_COUNT'}}'
-
-sysctlInitContainer:
-  enabled: true
-
-keystore: []
-
-# Deprecated
-# please use the above podSecurityContext.fsGroup instead
-fsGroup: ""
-
-activationStoreBackend: "ElasticSearch"
-indexPattern: "openwhisk-%s"
-username: "admin"
-password: "admin"
+  extraInitContainers: []
+  # This is the PriorityClass settings as defined in
+  # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+  priorityClassName: ""
+  # By default this will make sure two pods don't end up on the same node
+  # Changing this to a region would allow you to spread pods across regions
+  antiAffinityTopologyKey: "kubernetes.io/hostname"
+  # Hard means that by default pods will only be scheduled if there are enough nodes for them
+  # and that they will never end up on the same node. Setting this to soft will do this "best effort"
+  antiAffinity: "hard"
+  # This is the node affinity settings as defined in
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+  nodeAffinity: {}
+  # The default is to deploy all pods serially. By setting this to parallel all pods are started at
+  # the same time when bootstrapping the cluster
+  podManagementPolicy: "Parallel"
+  # The environment variables injected by service links are not used, but can lead to slow Elasticsearch boot times when
+  # there are many services in the current namespace.
+  # If you experience slow pod startups you probably want to set this to `false`.
+  enableServiceLinks: true
+  protocol: http
+  httpPort: 9200
+  transportPort: 9300
+  service:
+    labels: {}
+    labelsHeadless: {}
+    type: ClusterIP
+    nodePort: ""
+    annotations: {}
+    httpPortName: http
+    transportPortName: transport
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+  updateStrategy: RollingUpdate
+  podSecurityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+  securityContext:
+    capabilities:
+      drop:
+      - ALL
+    # readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+  # How long to wait for elasticsearch to stop gracefully
+  terminationGracePeriod: 120
+  sysctlVmMaxMapCount: 262144
+  readinessProbe:
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 3
+    timeoutSeconds: 5
+  # https://www.elastic.co/guide/en/elasticsearch/reference/7.8/cluster-health.html#request-params wait_for_status
+  clusterHealthCheckParams: "wait_for_status=green&timeout=1s"
+  ## Use an alternate scheduler.
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  imagePullSecrets: []
+  nodeSelector: {}
+  tolerations: []
+  nameOverride: ""
+  fullnameOverride: ""
+  # https://github.com/elastic/helm-charts/issues/63
+  masterTerminationFix: false
+  lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+    # postStart:
+    #   exec:
+    #     command:
+    #       - bash
+    #       - -c
+    #       - |
+    #         #!/bin/bash
+    #         # Add a template to adjust number of shards/replicas
+    #         TEMPLATE_NAME=my_template
+    #         INDEX_PATTERN="logstash-*"
+    #         SHARD_COUNT=8
+    #         REPLICA_COUNT=1
+    #         ES_URL=http://localhost:9200
+    #         while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' $ES_URL)" != "200" ]]; do sleep 1; done
+    #         curl -XPUT "$ES_URL/_template/$TEMPLATE_NAME" -H 'Content-Type: application/json' -d'{"index_patterns":['\""$INDEX_PATTERN"\"'],"settings":{"number_of_shards":'$SHARD_COUNT',"number_of_replicas":'$REPLICA_COUNT'}}'
+  sysctlInitContainer:
+    enabled: true
+  keystore: []
+  # Deprecated
+  # please use the above podSecurityContext.fsGroup instead
+  fsGroup: ""
+  indexPattern: "openwhisk-%s"
+  username: "admin"
+  password: "admin"

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -759,3 +759,5 @@ fsGroup: ""
 
 activationStoreBackend: "ElasticSearch"
 indexPattern: "openwhisk-%s"
+username: "admin"
+password: "admin"

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -229,7 +229,8 @@ db:
   persistence:
     size: 2Gi
 
-activationStoreBackend: "ElasticSearch"
+# CouchDB, ElasticSearch
+activationStoreBackend: "CouchDB"
 
 # Nginx configurations
 nginx:
@@ -609,6 +610,8 @@ elasticsearch:
   # If you experience slow pod startups you probably want to set this to `false`.
   enableServiceLinks: true
   protocol: http
+  connect_string: null
+  host: null
   httpPort: 9200
   transportPort: 9300
   service:

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -590,18 +590,6 @@ elasticsearch:
   #   image: busybox
   #   command: ['do', 'something']
   extraInitContainers: []
-  # This is the PriorityClass settings as defined in
-  # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-  priorityClassName: ""
-  # By default this will make sure two pods don't end up on the same node
-  # Changing this to a region would allow you to spread pods across regions
-  antiAffinityTopologyKey: "kubernetes.io/hostname"
-  # Hard means that by default pods will only be scheduled if there are enough nodes for them
-  # and that they will never end up on the same node. Setting this to soft will do this "best effort"
-  antiAffinity: "hard"
-  # This is the node affinity settings as defined in
-  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
-  nodeAffinity: {}
   # The default is to deploy all pods serially. By setting this to parallel all pods are started at
   # the same time when bootstrapping the cluster
   podManagementPolicy: "Parallel"


### PR DESCRIPTION
- [x] Add activation store backend: `ElasticSearch`
- [x] Support external elasticsearch
- [x] Add document

Refer to:
* Implement an ElasticSearchActivationStore: https://github.com/apache/openwhisk/pull/4724
* elasticsearch in helm: https://github.com/elastic/helm-charts

I tested below scenes, worked well  (after executed `wsk -i action invoke ${action}`, can get activation successfully using `wsk -i activation get ${activationId}`)
* Use default activation store backend: `CouchDB`
* Use activation store backend: `ElasticSearch`  (create elasticsearch pod)
* Use external `ElasticSearch` for activation store