### PR TITLE
Make nginx pod starts after controller pod

### DIFF
--- a/helm/openwhisk/templates/nginx-pod.yaml
+++ b/helm/openwhisk/templates/nginx-pod.yaml
@@ -63,6 +63,9 @@ spec:
       - name: logs
         emptyDir: {}
 {{ include "openwhisk.docker.imagePullSecrets" . | indent 6 }}
+      initContainers:
+      # Wait for a controller to be up (which implies kafka, zookeeper, couchdb are all up as well).
+{{ include "openwhisk.readiness.waitForController" . | indent 6 }}
       containers:
       - name: nginx
         image: "{{- .Values.docker.registry.name -}}{{- .Values.nginx.imageName -}}:{{- .Values.nginx.imageTag -}}"


### PR DESCRIPTION
- [x] Make nginx pod starts after controller pod
 
 Because nginx pod's has configuration which pointed to controller svc address, so it is better to adjust the nginx pod's start order(make nginx pod starts after controller pod)