### PR TITLE
Add helm release to invoker pod

### DIFF
--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -205,6 +205,8 @@ spec:
           - name: "CONFIG_whisk_spi_ActivationStoreProvider"
             value: "org.apache.openwhisk.core.database.elasticsearch.ElasticSearchActivationStoreProvider"
 {{- end }}
+          - name: "CONFIG_whisk_helm_release"
+            value: "{{ .Release.Name }}"
         ports:
         - name: invoker
           containerPort: {{ .Values.invoker.port }}


### PR DESCRIPTION
If want to deploy two helm release openwhisk cluster,  when the second helm release cluster's invokerN pod is restarting, it will delete the first helm release's invokerN runtime pods.

Because when invokerN pod is starting, it will delete  runtime pods with label(invoker=invokerN) only. e.g.
https://github.com/apache/openwhisk/blob/master/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala#L65

in order to avoid `delete other helm release invokerN's runtime pod`, it is better to add helm release to invoker pod, and when invoker pod is starting, add label(release=xxxxxx) together with label(invoker=invokerN) to delete runtime pods.

another brother pr: https://github.com/apache/openwhisk/pull/4979