### PR TITLE
deprecate kind go:1.11; add kind go1.15 using v1.16.0 runtime-go

### DIFF
--- a/helm/openwhisk/runtimes.json
+++ b/helm/openwhisk/runtimes.json
@@ -176,8 +176,8 @@
         "go": [
             {
                 "kind": "go:1.11",
-                "default": true,
-                "deprecated": false,
+                "default": false,
+                "deprecated": true,
                 "attached": {
                     "attachmentName": "codefile",
                     "attachmentType": "text/plain"
@@ -186,6 +186,20 @@
                     "prefix": "openwhisk",
                     "name": "action-golang-v1.11",
                     "tag": "1.15.0"
+                }
+            },
+            {
+                "kind": "go:1.15",
+                "default": true,
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                },
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "action-golang-v1.15",
+                    "tag": "1.16.0"
                 }
             }
         ],


### PR DESCRIPTION
Mirror core PR https://github.com/apache/openwhisk/pull/4987