### PR TITLE
Make busybox image configurable

### DIFF
--- a/helm/openwhisk/templates/_readiness.tpl
+++ b/helm/openwhisk/templates/_readiness.tpl
@@ -21,7 +21,7 @@
 # if not db.wipeAndInit, the external db must already be ready; so no need for init container
 {{- else -}}
 - name: "wait-for-couchdb"
-  image: "{{- .Values.docker.registry.name -}}busybox"
+  image: "{{- .Values.docker.registry.name -}}{{- .Values.busybox.imageName -}}:{{- .Values.busybox.imageTag -}}"
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
@@ -33,7 +33,7 @@
 {{/* Init container that waits for kafka to be ready */}}
 {{- define "openwhisk.readiness.waitForKafka" -}}
 - name: "wait-for-kafka"
-  image: "{{- .Values.docker.registry.name -}}busybox"
+  image: "{{- .Values.docker.registry.name -}}{{- .Values.busybox.imageName -}}:{{- .Values.busybox.imageTag -}}"
   imagePullPolicy: "IfNotPresent"
   # TODO: I haven't found an easy external test to determine that kafka is up, so as a hack we wait for zookeeper and then sleep for 10 seconds and cross our fingers!
   command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(echo ruok | nc -w 1 {{ include "openwhisk.zookeeper_zero_host" . }} {{ .Values.zookeeper.port }}); if [ "$OK" == "imok" ]; then result=0; echo "zookeeper returned imok!"; else echo waiting for zookeeper to be ready; sleep 1; fi done; echo "Zookeeper is up; will wait for 10 seconds to give kafka time to initialize"; sleep 10;']
@@ -42,7 +42,7 @@
 {{/* Init container that waits for zookeeper to be ready */}}
 {{- define "openwhisk.readiness.waitForZookeeper" -}}
 - name: "wait-for-zookeeper"
-  image: "{{- .Values.docker.registry.name -}}busybox"
+  image: "{{- .Values.docker.registry.name -}}{{- .Values.busybox.imageName -}}:{{- .Values.busybox.imageTag -}}"
   imagePullPolicy: "IfNotPresent"
   command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(echo ruok | nc -w 1 {{ include "openwhisk.zookeeper_zero_host" . }} {{ .Values.zookeeper.port }}); if [ "$OK" == "imok" ]; then result=0; echo "zookeeper returned imok!"; else echo waiting for zookeeper to be ready; sleep 1; fi; done; echo "Success: zookeeper is up"']
 {{- end -}}
@@ -50,7 +50,7 @@
 {{/* Init container that waits for controller to be ready */}}
 {{- define "openwhisk.readiness.waitForController" -}}
 - name: "wait-for-controller"
-  image: "{{- .Values.docker.registry.name -}}busybox"
+  image: "{{- .Values.docker.registry.name -}}{{- .Values.busybox.imageName -}}:{{- .Values.busybox.imageTag -}}"
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
@@ -61,7 +61,7 @@
 {{/* Init container that waits for at least 1 healthy invoker */}}
 {{- define "openwhisk.readiness.waitForHealthyInvoker" -}}
 - name: "wait-for-healthy-invoker"
-  image: "{{- .Values.docker.registry.name -}}busybox"
+  image: "{{- .Values.docker.registry.name -}}{{- .Values.busybox.imageName -}}:{{- .Values.busybox.imageTag -}}"
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"
@@ -72,7 +72,7 @@
 {{/* Init container that waits for ElasticSearch to be ready */}}
 {{- define "openwhisk.readiness.waitForElasticSearch" -}}
 - name: "wait-for-elasticsearch"
-  image: "{{- .Values.docker.registry.name -}}busybox"
+  image: "{{- .Values.docker.registry.name -}}{{- .Values.busybox.imageName -}}:{{- .Values.busybox.imageTag -}}"
   imagePullPolicy: "IfNotPresent"
   env:
   - name: "READINESS_URL"

--- a/helm/openwhisk/templates/redis-pod.yaml
+++ b/helm/openwhisk/templates/redis-pod.yaml
@@ -57,7 +57,7 @@ spec:
 {{- if .Values.k8s.persistence.enabled }}
       initContainers:
       - name: redis-init
-        image: "{{- .Values.docker.registry.name -}}busybox"
+        image: "{{- .Values.docker.registry.name -}}{{- .Values.busybox.imageName -}}:{{- .Values.busybox.imageTag -}}"
         command:
           - chown
           - -v

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -398,6 +398,10 @@ providers:
     apiPort: 8080
     dbPrefix: "kp"
 
+busybox:
+  imageName: "busybox"
+  imageTag: "latest"
+
 
 # Used to define pod affinity and anti-affinity for the Kubernetes scheduler.
 # If affinity.enabled is true, then all of the deployments for the OpenWhisk


### PR DESCRIPTION
when using a private docker registry, users may not have access to the root path, so they can not push busybox image to `xxx.xxx.xxx/busybox`

this PR makes busybox's image configurable to resolve above issue