### PR TITLE
Fix invalid kamonTags setting

### DIFF
--- a/helm/openwhisk/templates/controller-pod.yaml
+++ b/helm/openwhisk/templates/controller-pod.yaml
@@ -174,7 +174,7 @@ spec:
         - name: "METRICS_KAMON"
           value: "true"
 {{ end }}
-{{ if or .Values.metrics.kamonTags .Values.metrics.prometheusEnabled }}
+{{ if .Values.metrics.kamonTags }}
         - name: "METRICS_KAMON_TAGS"
           value: "true"
 {{ end }}

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -179,7 +179,7 @@ spec:
           - name: "METRICS_KAMON"
             value: "true"
 {{ end }}
-{{ if and .Values.metrics.kamonEnabled .Values.metrics.kamonTags }}
+{{ if .Values.metrics.kamonTags }}
           - name: "METRICS_KAMON_TAGS"
             value: "true"
 {{ end }}

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -179,7 +179,7 @@ spec:
           - name: "METRICS_KAMON"
             value: "true"
 {{ end }}
-{{ if and .Values.metrics.kamonTags .Values.metrics.prometheusEnabled }}
+{{ if or .Values.metrics.kamonTags .Values.metrics.prometheusEnabled }}
           - name: "METRICS_KAMON_TAGS"
             value: "true"
 {{ end }}

--- a/helm/openwhisk/templates/invoker-pod.yaml
+++ b/helm/openwhisk/templates/invoker-pod.yaml
@@ -179,7 +179,7 @@ spec:
           - name: "METRICS_KAMON"
             value: "true"
 {{ end }}
-{{ if or .Values.metrics.kamonTags .Values.metrics.prometheusEnabled }}
+{{ if and .Values.metrics.kamonEnabled .Values.metrics.kamonTags }}
           - name: "METRICS_KAMON_TAGS"
             value: "true"
 {{ end }}


### PR DESCRIPTION
## Description
There was an issue that the invoker's kamonTags setting was not applied. 
On the other hand, the controller had no problem.

I've found a problem with the conditional and fixed it.
(The kamon tag setting is independent of Prometheus.)