### PR TITLE
add-scc-to-user to owdev-init-sa

### DIFF
--- a/docs/okd-311.md
+++ b/docs/okd-311.md
@@ -41,6 +41,8 @@ oc adm policy add-scc-to-user anyuid -z default
 oc adm policy add-scc-to-user privileged -z default
 oc adm policy add-scc-to-user anyuid -z openwhisk-core
 oc adm policy add-scc-to-user privileged -z openwhisk-core
+oc adm policy add-scc-to-user anyuid -z owdev-init-sa
+oc adm policy add-scc-to-user privileged -z owdev-init-sa
 ```
 
 ## Configuring OpenWhisk


### PR DESCRIPTION
To Avoid Write permission on cert folder....

Tested on OKD/OpenShift 4.5 works well...