### PR TITLE
Optimize nginx configuration

### DIFF
--- a/helm/openwhisk/templates/nginx-cm.yaml
+++ b/helm/openwhisk/templates/nginx-cm.yaml
@@ -24,6 +24,7 @@ metadata:
 {{ include "openwhisk.label_boilerplate" . | indent 4 }}
 data:
   nginx.conf: |
+    worker_processes {{ .Values.nginx.workerProcesses }};
     worker_rlimit_nofile 4096;
 
     events {
@@ -44,6 +45,17 @@ data:
       # needed to enable keepalive to upstream controllers
       proxy_http_version 1.1;
       proxy_set_header Connection "";
+
+      upstream controllers {
+         # Mark the controller as unavailable after fail_timeout seconds, to not get any requests during restart.
+         # Otherwise, nginx would dispatch requests when the container is up, but the backend in the container not.
+         # From the docs:
+         #  "normally, requests with a non-idempotent method (POST, LOCK, PATCH) are not passed to
+         #   the next server if a request has been sent to an upstream server"
+         server {{ include "openwhisk.controller_host" . }}:{{ .Values.controller.port }} fail_timeout=60s;
+
+         keepalive 512;
+      }
 
       server {
         listen 80;
@@ -72,7 +84,6 @@ data:
 
         # Hack to convince nginx to dynamically resolve the dns entries.
         resolver {{ .Values.k8s.dns }};
-        set $controllers {{ include "openwhisk.controller_host" . }};
 {{- if or (eq .Values.whisk.ingress.type "NodePort") (eq .Values.whisk.ingress.type "LoadBalancer") }}
         set $apigw {{ include "openwhisk.apigw_host" . }};
 {{ if or .Values.metrics.prometheusEnabled .Values.metrics.userMetricsEnabled }}
@@ -85,12 +96,12 @@ data:
             if ($namespace) {
                 rewrite    /(.*) /api/v1/web/${namespace}/$1 break;
             }
-            proxy_pass http://$controllers:{{ .Values.controller.port }};
+            proxy_pass http://controllers;
             proxy_read_timeout 75s; # 70+5 additional seconds to allow controller to terminate request
         }
 
         location /api/v1 {
-            proxy_pass http://$controllers:{{ .Values.controller.port }};
+            proxy_pass http://controllers;
             proxy_read_timeout 75s; # 70+5 additional seconds to allow controller to terminate request
         }
 
@@ -116,7 +127,7 @@ data:
             if ($namespace) {
               rewrite    /(.*) /api/v1/web/${namespace}/$1 break;
             }
-            proxy_pass http://$controllers:{{ .Values.controller.port }};
+            proxy_pass http://controllers;
             proxy_read_timeout 75s; # 70+5 additional seconds to allow controller to terminate request
         }
 

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -240,6 +240,7 @@ nginx:
   httpPort: 80
   httpsPort: 443
   httpsNodePort: 31001
+  workerProcesses: "auto"
   certificate:
     external: false
     cert_file: ""


### PR DESCRIPTION
- Add nginx worker_processes
After changed to `auto`, the performance increases a lot during benchmark
- Add upstream section
Before changed to upsteam, the tps under our env is
![image](https://user-images.githubusercontent.com/11749867/105649726-5538a300-5eec-11eb-9830-6f364c8a334e.png)
After added the upsteam section, the tps is
![image](https://user-images.githubusercontent.com/11749867/105649772-739e9e80-5eec-11eb-81c5-e5a9b6415c19.png)
controller replicaCount: `2`, invoker replicaCount: `4`, benchmark 10 hello actions at the same time.
(BTW, when i benchmarked this point, i didn't add `worker_processes: auto`)

Above 2 configuration can impove the performance both