### PR TITLE
Add backquotes for file names in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Configure the OpenWhisk CLI, wsk, by setting the auth and apihost
 properties (if you don't already have the wsk cli, follow the
 instructions [here](https://github.com/apache/openwhisk-cli)
 to get it). Replace `whisk.ingress.apiHostName` and `whisk.ingress.apiHostPort`
-with the actual values from your mycluster.yaml.
+with the actual values from your `mycluster.yaml`.
 ```shell
 wsk property set --apihost <whisk.ingress.apiHostName>:<whisk.ingress.apiHostPort>
 wsk property set --auth 23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
@@ -306,7 +306,7 @@ host environment. Instead, exposed NodePorts are forwarded from localhost
 to the appropriate containers.  This means that you will use `localhost`
 instead of `whisk.ingress.apiHostName` when configuring
 the `wsk` cli and replace `whisk.ingress.apiHostPort`
-with the actual values from your mycluster.yaml.
+with the actual values from your `mycluster.yaml`.
 
 ```shell
 wsk property set --apihost localhost:<whisk.ingress.apiHostPort>

--- a/docs/configurationChoices.md
+++ b/docs/configurationChoices.md
@@ -157,20 +157,23 @@ approach to provisioning dynamic storage if it's not already provisioned
 on your cluster.
 
 If your cluster is not thus configured and you want to use persistence,
-then you will need to add the following stanza to your mycluster.yaml.
+then you will need to add the following stanza to your `mycluster.yaml`.
+
 ```yaml
 k8s:
   persistence:
     hasDefaultStorageClass: false
     explicitStorageClass: <DESIRED_STORAGE_CLASS_NAME>
 ```
+
 If <DESIRED_STORAGE_CLASS_NAME> has a dynamic provisioner, deploying
 the Helm chart will automatically create the required PersistentVolumes.
 If <DESIRED_STORAGE_CLASS_NAME> does not have a dynamic provisioner,
 then you will need to manually create the required persistent volumes.
 
 Alternatively, you may also entirely disable the usage of persistence
-by adding the following stanza to your mycluster.yaml:
+by adding the following stanza to your `mycluster.yaml`:
+
 ```yaml
 k8s:
   persistence:

--- a/docs/k8s-aws.md
+++ b/docs/k8s-aws.md
@@ -64,8 +64,10 @@ A typical output would be as shown below
     ]
 }
 ```
-Add the following to your mycluster.yaml, using your certificate's Arn
+
+Add the following to your `mycluster.yaml`, using your certificate's Arn
 instead of the example one:
+
 ```yaml
 whisk:
   ingress:

--- a/docs/k8s-docker-for-mac.md
+++ b/docs/k8s-docker-for-mac.md
@@ -52,7 +52,7 @@ might also have installed on your machine.  Finally, pick the
 You will be using a NodePort ingress to access OpenWhisk. Assuming
 `kubectl describe nodes | grep InternalIP` returns 192.168.65.3 and
 port 31001 is available to be used on your host machine, a
-mycluster.yaml for a standard deployment of OpenWhisk would be:
+`mycluster.yaml` for a standard deployment of OpenWhisk would be:
 ```yaml
 whisk:
   ingress:

--- a/docs/k8s-docker-for-windows.md
+++ b/docs/k8s-docker-for-windows.md
@@ -62,7 +62,7 @@ the box to enable Kubernetes.
 You will be using a NodePort ingress to access OpenWhisk. Assuming
 `kubectl describe nodes | find "InternalIP"` returns 192.168.65.3 and
 port 31001 is available to be used on your host machine, a
-mycluster.yaml for a standard deployment of OpenWhisk would be:
+`mycluster.yaml` for a standard deployment of OpenWhisk would be:
 
 ```yaml
 whisk:

--- a/docs/k8s-kind.md
+++ b/docs/k8s-kind.md
@@ -75,15 +75,18 @@ kubectl label node kind-worker2 openwhisk-role=invoker
 
 ### Configuring OpenWhisk
 
-To configure OpenWhisk, you first need to define a mycluster.yaml
+To configure OpenWhisk, you first need to define a `mycluster.yaml`
 that specifies the "inside the cluster" ingress information and
 other system configuration. First, determine the internalIP of
 a worker node with the command:
+
 ```
 kubectl describe node kind-worker | grep InternalIP: | awk '{print $2}'
 ```
-A mycluster.yaml for a standard deployment of OpenWhisk would look
+
+A `mycluster.yaml` for a standard deployment of OpenWhisk would look
 like the below, replacing <InternalIP> with its actual value:
+
 ```yaml
 whisk:
   ingress:


### PR DESCRIPTION
Hi, I'm new to OpenWhisk 😄 

When reading these docs to deploy OpenWhisk, I noticed the inconsistent use of backquotes for file names: sometimes it's `` `mycluster.yaml` ``  while sometimes it's just plain `mycluster.yaml`. I think the former looks better and thus make this PR.