### PR TITLE
Update helm to make secret instead of configmap for Nginx External Cert usage

### DIFF
--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -335,14 +335,14 @@ imagePullSecrets:
 {{/* nginx cert */}}
 {{- define "openwhisk.nginx_cert" -}}
 {{- if .Values.nginx.certificate.external }}
-{{ .Files.Get .Values.nginx.certificate.cert_file }}
+{{ .Values.nginx.certificate.cert_file | .Files.Get }}
 {{- end -}}
 {{- end -}}
 
 {{/* nginx key */}}
 {{- define "openwhisk.nginx_key" -}}
 {{- if .Values.nginx.certificate.external }}
-{{ .Files.Get .Values.nginx.certificate.key_file }}
+{{ .Values.nginx.certificate.key_file | .Files.Get }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/openwhisk/templates/_helpers.tpl
+++ b/helm/openwhisk/templates/_helpers.tpl
@@ -335,14 +335,14 @@ imagePullSecrets:
 {{/* nginx cert */}}
 {{- define "openwhisk.nginx_cert" -}}
 {{- if .Values.nginx.certificate.external }}
-{{ .Values.nginx.certificate.cert_file | .Files.Get }}
+{{ .Files.Get .Values.nginx.certificate.cert_file | b64enc }}
 {{- end -}}
 {{- end -}}
 
 {{/* nginx key */}}
 {{- define "openwhisk.nginx_key" -}}
 {{- if .Values.nginx.certificate.external }}
-{{ .Values.nginx.certificate.key_file | .Files.Get }}
+{{ .Files.Get .Values.nginx.certificate.key_file | b64enc }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/openwhisk/templates/gen-certs-secret.yaml
+++ b/helm/openwhisk/templates/gen-certs-secret.yaml
@@ -17,7 +17,7 @@
 
 {{- if or (eq .Values.whisk.ingress.type "NodePort") (eq .Values.whisk.ingress.type "LoadBalancer") }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ .Release.Name }}-gen-certs
   labels:

--- a/helm/openwhisk/templates/nginx-pod.yaml
+++ b/helm/openwhisk/templates/nginx-pod.yaml
@@ -50,8 +50,8 @@ spec:
       {{- if or (eq .Values.whisk.ingress.type "NodePort") (eq .Values.whisk.ingress.type "LoadBalancer") }}
       {{- if .Values.nginx.certificate.external }}
       - name: nginx-certs
-        configMap:
-          name: {{ .Release.Name }}-gen-certs
+        secret:
+          secretName: {{ .Release.Name }}-gen-certs
       {{- else }}
       - name: nginx-certs
         secret:


### PR DESCRIPTION
In my quest to use my own certs with an internal CA, and with some great help from @style95 I was able to make significant headway and get my deployment working as desired. I did want to make a small tweak so the external cert for nginx is not stored as a configmap, but instead as a secret. (I realize there's not a ton of difference under the hood but it helps me sleep better at night) I have not tested this with any other deployment types, so feel free to give any feedback as needed.