### PR TITLE
Add missing PVC for alarmprovider

### DIFF
--- a/helm/openwhisk/README.md
+++ b/helm/openwhisk/README.md
@@ -37,7 +37,7 @@ In its default configuration, this chart will create the following Kubernetes re
 * Internal Services
    * apigateway, controller, couchdb, kafka, nginx, redis, zookeeper
 * OpenWhisk control plane Pods:
-   * Deployments: apigateway, couchdb, nginx, redis
+   * Deployments: apigateway, couchdb, nginx, redis, alarmprovider
    * StatefulSets: controller, invoker, kafka, zookeeper
 * Persistent Volume Claims
    * alarmprovider-pvc

--- a/helm/openwhisk/README.md
+++ b/helm/openwhisk/README.md
@@ -40,6 +40,7 @@ In its default configuration, this chart will create the following Kubernetes re
    * Deployments: apigateway, couchdb, nginx, redis
    * StatefulSets: controller, invoker, kafka, zookeeper
 * Persistent Volume Claims
+   * alarmprovider-pvc
    * couchdb-pvc
    * kafka-pvc
    * redis-pvc
@@ -67,7 +68,7 @@ If Container Image Security is enabled, you will not be able to download non-tru
 
 ### Persistent Volume Requirements
 
-This chart requires 5 Persistent Volumes to be created to avoid loss of data.  One of the following must be true to satisfy the Persistent Volume requirements for this chart:
+This chart requires 6 Persistent Volumes to be created to avoid loss of data.  One of the following must be true to satisfy the Persistent Volume requirements for this chart:
 
 * When the chart is deployed, the value `k8s.persistence.enabled` is set to false to disable usage of Persistent Volumes (for development and test activities).
 * The Kubernetes cluster supports Dynamic Volume Provisioning and has a default StorageClass defined with an associated provisioner.


### PR DESCRIPTION
The documentation for Helm is missing a PVC for the Alarmprovider. The PVCs total to 6, not 5.  
This pull request adapts the documentation accordingly.