### PR TITLE
Prevent etcd from running when scheduler disabled

### DIFF
--- a/helm/openwhisk/templates/etcd-pod.yaml
+++ b/helm/openwhisk/templates/etcd-pod.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{ if not .Values.etcd.external }}
+{{- if and (.Values.scheduler.enabled) (not .Values.etcd.external) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -111,4 +111,4 @@ spec:
           ports:
           - name: etcd
             containerPort: {{ .Values.etcd.port }}
-{{ end }}
+{{- end }}

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -139,9 +139,9 @@ whisk:
     includeSystemTests: false
   versions:
     openwhisk:
-      buildDate: "2022-09-13-02:40:10Z"
-      buildNo: "20220912"
-      gitTag: "a1639f0e4d7270c9a230190ac26acb61413b6bbb"
+      buildDate: "2022-10-14-13:44:50Z"
+      buildNo: "20221014"
+      gitTag: "ef725a653ab112391f79c274d8e3dcfb915d59a3"
     openwhiskCli:
       tag: "1.1.0"
     openwhiskCatalog:
@@ -162,7 +162,7 @@ k8s:
 # Images used to run auxillary tasks/jobs
 utility:
   imageName: "openwhisk/ow-utils"
-  imageTag: "a1639f0"
+  imageTag: "ef725a6"
   imagePullPolicy: "IfNotPresent"
 
 # Docker registry
@@ -260,7 +260,7 @@ nginx:
 # Controller configurations
 controller:
   imageName: "openwhisk/controller"
-  imageTag: "a1639f0"
+  imageTag: "ef725a6"
   imagePullPolicy: "IfNotPresent"
   replicaCount: 1
   restartPolicy: "Always"
@@ -274,7 +274,7 @@ controller:
 scheduler:
   enabled: false
   imageName: "openwhisk/scheduler"
-  imageTag: "a1639f0"
+  imageTag: "ef725a6"
   imagePullPolicy: "IfNotPresent"
   replicaCount: 1
   restartPolicy: "Always"
@@ -331,7 +331,7 @@ etcd:
 # Invoker configurations
 invoker:
   imageName: "openwhisk/invoker"
-  imageTag: "a1639f0"
+  imageTag: "ef725a6"
   imagePullPolicy: "IfNotPresent"
   restartPolicy: "Always"
   runtimeDeleteTimeout: "30 seconds"
@@ -386,7 +386,7 @@ redis:
 # User-events configuration
 user_events:
   imageName: "openwhisk/user-events"
-  imageTag: "a1639f0"
+  imageTag: "ef725a6"
   imagePullPolicy: "IfNotPresent"
   replicaCount: 1
   restartPolicy: "Always"


### PR DESCRIPTION
I recently noticed that etcd was running even when the scheduler is disabled. This PR exists primarily to fix this bug.

However, since I was already making a PR, I also briefly tested deployment with the most recent OpenWhisk images, and updated them here (there have been some updates to the scheduler since the last image was accepted here).