### PR TITLE
fix: respect some values in values.yaml

### DIFF
--- a/helm/openwhisk/templates/elasticsearch-svc.yaml
+++ b/helm/openwhisk/templates/elasticsearch-svc.yaml
@@ -30,6 +30,15 @@ metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
+  type: {{ .Values.elasticsearch.service.type }}
+  {{- if eq .Values.elasticsearch.service.type "NodePort" }}
+  nodePort: {{ .Values.elasticsearch.service.nodePort }}
+  {{- end }}
+  {{- if eq .Values.elasticsearch.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ .Values.elasticsearch.service.loadBalancerIP }}
+  loadBalancerSourceRanges:
+  {{- toYaml .Values.elasticsearch.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end }}
   clusterIP: None # This is needed for statefulset hostnames like elasticsearch-0 to resolve
   # Create endpoints also if the related pod isn't ready
   publishNotReadyAddresses: true

--- a/helm/openwhisk/templates/grafana-pod.yaml
+++ b/helm/openwhisk/templates/grafana-pod.yaml
@@ -63,6 +63,7 @@ spec:
       containers:
         - name: grafana
           image: "{{- .Values.docker.registry.name -}}{{- .Values.grafana.imageName -}}:{{- .Values.grafana.imageTag -}}"
+          imagePullPolicy: {{ .Values.grafana.imagePullPolicy }}
           env:
           - name: "GF_AUTH_ANONYMOUS_ENABLED"
             value: "true"


### PR DESCRIPTION
Fixes #784 respect [grafana.imagePullPolicy](https://github.com/apache/openwhisk-deploy-kube/blob/108f327580f04c51dc4b29ac0beff024cfd6f2f9/helm/openwhisk/values.yaml#L412), [elasticsearch.service.type](https://github.com/apache/openwhisk-deploy-kube/blob/108f327580f04c51dc4b29ac0beff024cfd6f2f9/helm/openwhisk/values.yaml#L686C5-L686C9), [elasticsearch.service.nodePort](https://github.com/apache/openwhisk-deploy-kube/blob/108f327580f04c51dc4b29ac0beff024cfd6f2f9/helm/openwhisk/values.yaml#L687), [elasticsearch.service.loadBalancerIP](https://github.com/apache/openwhisk-deploy-kube/blob/108f327580f04c51dc4b29ac0beff024cfd6f2f9/helm/openwhisk/values.yaml#L691), and [elasticsearch.service.loadBalancerSourceRanges](https://github.com/apache/openwhisk-deploy-kube/blob/108f327580f04c51dc4b29ac0beff024cfd6f2f9/helm/openwhisk/values.yaml#L692)