### PR TITLE
Made the deployment of the API Gateway optional. 

### DIFF
--- a/helm/openwhisk/templates/apigateway-pod.yaml
+++ b/helm/openwhisk/templates/apigateway-pod.yaml
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+{{- if .Values.apigw.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,3 +72,4 @@ spec:
               configMapKeyRef:
                 name: {{ .Release.Name }}-whisk.config
                 key: whisk_internal_api_host_url
+{{- end }}

--- a/helm/openwhisk/templates/apigateway-svc.yaml
+++ b/helm/openwhisk/templates/apigateway-svc.yaml
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+{{- if .Values.apigw.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,3 +31,4 @@ spec:
       name: mgmt
     - port: {{ .Values.apigw.apiPort }}
       name: api
+{{- end }}

--- a/helm/openwhisk/templates/install-packages-job.yaml
+++ b/helm/openwhisk/templates/install-packages-job.yaml
@@ -72,6 +72,8 @@ spec:
                 name: {{ .Release.Name }}-whisk.config
                 key: whisk_internal_api_host_url
           # apigateway configuration (for installing routemgmt actions)
+          - name: "WHISK_API_GATEWAY_ENABLED"
+            value: {{ if .Values.apigw.enabled }} "yes" {{ else }} "no" {{ end }}
           - name: "WHISK_SYSTEM_NAMESPACE"
             valueFrom:
               configMapKeyRef:

--- a/helm/openwhisk/templates/redis-pod.yaml
+++ b/helm/openwhisk/templates/redis-pod.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{ if not .Values.redis.external }}
+{{ if and .Values.apigw.enabled (not .Values.redis.external) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/openwhisk/templates/redis-pvc.yaml
+++ b/helm/openwhisk/templates/redis-pvc.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{- if and (not .Values.redis.external) .Values.k8s.persistence.enabled }}
+{{- if and .Values.apigw.enabled (not .Values.redis.external) .Values.k8s.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/openwhisk/templates/redis-svc.yaml
+++ b/helm/openwhisk/templates/redis-svc.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-{{ if not .Values.redis.external }}
+{{ if and .Values.apigw.enabled (not .Values.redis.external) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/openwhisk/templates/tests/smoketest-pod.yaml
+++ b/helm/openwhisk/templates/tests/smoketest-pod.yaml
@@ -53,4 +53,6 @@ spec:
           configMapKeyRef:
             name: {{ .Release.Name }}-whisk.config
             key: whisk_internal_api_host_url
+      - name: "WSK_API_GATEWAY_ENABLED"
+        value: {{ if .Values.apigw.enabled }} "yes" {{ else }} "no" {{ end }}
 {{- end }}

--- a/helm/openwhisk/values.yaml
+++ b/helm/openwhisk/values.yaml
@@ -360,6 +360,7 @@ invoker:
 
 # API Gateway configurations
 apigw:
+  enabled: true # Disabling this also disables Redis
   imageName: "openwhisk/apigateway"
   imageTag: "1.0.0"
   imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
Setting `.Values.apigw.enabled` to false disables the deployment of the API gateway and the Redis databases. Environment variables have been added to the smoke test and install packages jobs so that API gateway related tasks are also disabled.